### PR TITLE
Fix/line bot

### DIFF
--- a/templates/line-bot/.github/workflows/install-line-bot.yml
+++ b/templates/line-bot/.github/workflows/install-line-bot.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: duotify/GitHubClawToolkit
-          ref: fix/line-bot
+          ref: main
           path: template-source
           sparse-checkout: |
             workers/line-bot

--- a/templates/line-bot/.github/workflows/install-line-bot.yml
+++ b/templates/line-bot/.github/workflows/install-line-bot.yml
@@ -8,12 +8,12 @@ on:
         required: false
         type: string
       line_bot_id:
-        description: LINE Bot ID
-        required: true
+        description: LINE Bot ID（未填時沿用 repo variable）
+        required: false
         type: string
       line_bot_channel_id:
-        description: LINE Bot Channel ID
-        required: true
+        description: LINE Bot Channel ID（未填時沿用 repo variable）
+        required: false
         type: string
       line_default_reply_message:
         description: LINE Bot 預設回應訊息
@@ -25,10 +25,12 @@ on:
         default: "+08:00"
         type: string
 
-run-name: "🚀 安裝 LINEBotWorker - ${{ inputs.line_bot_id }}"
+run-name: "🚀 安裝 LINEBotWorker - ${{ inputs.line_bot_id || vars.LINE_BOT_ID || 'line-bot' }}"
 
 permissions:
+  actions: write
   contents: read
+  issues: write
 
 concurrency:
   group: install-line-bot-${{ github.repository }}
@@ -170,6 +172,89 @@ jobs:
             exit 1
           fi
 
+      - name: 解析 LINE Bot 設定
+        id: resolve_line_config
+        shell: bash
+        env:
+          INPUT_LINE_BOT_ID: ${{ inputs.line_bot_id }}
+          INPUT_LINE_CHANNEL_ID: ${{ inputs.line_bot_channel_id }}
+          INPUT_LINE_DEFAULT_REPLY_MESSAGE: ${{ inputs.line_default_reply_message }}
+          INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
+          VAR_LINE_BOT_ID: ${{ vars.LINE_BOT_ID }}
+          VAR_LINE_CHANNEL_ID: ${{ vars.LINE_CHANNEL_ID }}
+        run: |
+          set -euo pipefail
+
+          resolve_required() {
+            local input_value="$1"
+            local fallback_value="$2"
+            local key="$3"
+            local value="${input_value}"
+            if [[ -z "${value}" ]]; then
+              value="${fallback_value}"
+            fi
+            if [[ -z "${value}" ]]; then
+              echo "::error::${key} 缺少值，請在部署時輸入或先寫入 repo variable"
+              exit 1
+            fi
+            printf '%s' "${value}"
+          }
+
+          LINE_BOT_ID="$(resolve_required "${INPUT_LINE_BOT_ID}" "${VAR_LINE_BOT_ID}" "LINE_BOT_ID")"
+          LINE_CHANNEL_ID="$(resolve_required "${INPUT_LINE_CHANNEL_ID}" "${VAR_LINE_CHANNEL_ID}" "LINE_CHANNEL_ID")"
+
+          {
+            echo "line_bot_id=${LINE_BOT_ID}"
+            echo "line_channel_id=${LINE_CHANNEL_ID}"
+            echo "issue_number=${INPUT_ISSUE_NUMBER}"
+            echo 'line_default_reply_message<<EOF'
+            printf '%s\n' "${INPUT_LINE_DEFAULT_REPLY_MESSAGE}"
+            echo 'EOF'
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: 同步 LINE Bot 設定到 GitHub Variables
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CLAW_SYS_GITHUB_TOKEN || github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const variables = {
+              LINE_BOT_ID: `${{ steps.resolve_line_config.outputs.line_bot_id }}`,
+              LINE_CHANNEL_ID: `${{ steps.resolve_line_config.outputs.line_channel_id }}`,
+            };
+
+            for (const [name, value] of Object.entries(variables)) {
+              try {
+                await github.rest.actions.updateRepoVariable({ owner, repo, name, value });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.actions.createRepoVariable({ owner, repo, name, value });
+              }
+            }
+
+      - name: 建立 linebotworker label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CLAW_SYS_GITHUB_TOKEN || github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const name = 'linebotworker';
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name,
+                color: '1D76DB',
+                description: 'Issues created by LINEBotWorker',
+              });
+            }
+
       - name: 同步 LINEBotWorker secrets
         shell: bash
         working-directory: template-source/workers/line-bot
@@ -177,12 +262,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           WORKER_NAME: ${{ steps.worker_name.outputs.worker_name }}
-          ISSUE_NUMBER: ${{ inputs.issue_number }}
-          LINE_BOT_ID: ${{ inputs.line_bot_id }}
-          LINE_CHANNEL_ID: ${{ inputs.line_bot_channel_id }}
+          ISSUE_NUMBER: ${{ steps.resolve_line_config.outputs.issue_number }}
+          LINE_BOT_ID: ${{ steps.resolve_line_config.outputs.line_bot_id }}
+          LINE_CHANNEL_ID: ${{ steps.resolve_line_config.outputs.line_channel_id }}
           LINE_CHANNEL_SECRET: ${{ secrets.LINE_CHANNEL_SECRET }}
           LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
-          LINE_DEFAULT_REPLY_MESSAGE: ${{ inputs.line_default_reply_message }}
+          LINE_DEFAULT_REPLY_MESSAGE: ${{ steps.resolve_line_config.outputs.line_default_reply_message }}
           DEFAULT_UTC_OFFSET: ${{ inputs.default_utc_offset }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}
@@ -263,10 +348,10 @@ jobs:
         shell: bash
         env:
           WORKER_NAME: ${{ steps.worker_name.outputs.worker_name }}
-          LINE_BOT_ID: ${{ inputs.line_bot_id }}
-          LINE_CHANNEL_ID: ${{ inputs.line_bot_channel_id }}
+          LINE_BOT_ID: ${{ steps.resolve_line_config.outputs.line_bot_id }}
+          LINE_CHANNEL_ID: ${{ steps.resolve_line_config.outputs.line_channel_id }}
           WORKER_URL: ${{ steps.deploy.outputs.deployment-url }}
-          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          ISSUE_NUMBER: ${{ steps.resolve_line_config.outputs.issue_number }}
         run: |
           WEBHOOK_URL="${WORKER_URL}/line/webhook"
           {
@@ -279,7 +364,7 @@ jobs:
             echo "| LINE Webhook URL | \`${WEBHOOK_URL}\` |"
             echo "| LINE Bot ID | \`${LINE_BOT_ID}\` |"
             echo "| LINE Bot Channel ID | \`${LINE_CHANNEL_ID}\` |"
-            echo "| Issue 綁定模式 | ${{ inputs.issue_number != '' && 'fixed' || 'dynamic-by-source' }} |"
+            echo "| Issue 綁定模式 | ${{ steps.resolve_line_config.outputs.issue_number != '' && 'fixed' || 'dynamic-by-source' }} |"
             echo "| 固定 Issue | ${ISSUE_NUMBER:-_dynamic_} |"
             echo "| DEFAULT_UTC_OFFSET | ${{ inputs.default_utc_offset }} |"
             echo ""

--- a/templates/line-bot/.github/workflows/install-line-bot.yml
+++ b/templates/line-bot/.github/workflows/install-line-bot.yml
@@ -8,12 +8,12 @@ on:
         required: false
         type: string
       line_bot_id:
-        description: LINE Bot ID（未填時沿用 repo variable）
-        required: false
+        description: LINE Bot ID
+        required: true
         type: string
       line_bot_channel_id:
-        description: LINE Bot Channel ID（未填時沿用 repo variable）
-        required: false
+        description: LINE Bot Channel ID
+        required: true
         type: string
       line_default_reply_message:
         description: LINE Bot 預設回應訊息
@@ -25,10 +25,9 @@ on:
         default: "+08:00"
         type: string
 
-run-name: "🚀 安裝 LINEBotWorker - ${{ inputs.line_bot_id || vars.LINE_BOT_ID || 'line-bot' }}"
+run-name: "🚀 安裝 LINEBotWorker - ${{ inputs.line_bot_id }}"
 
 permissions:
-  actions: write
   contents: read
   issues: write
 
@@ -172,67 +171,6 @@ jobs:
             exit 1
           fi
 
-      - name: 解析 LINE Bot 設定
-        id: resolve_line_config
-        shell: bash
-        env:
-          INPUT_LINE_BOT_ID: ${{ inputs.line_bot_id }}
-          INPUT_LINE_CHANNEL_ID: ${{ inputs.line_bot_channel_id }}
-          INPUT_LINE_DEFAULT_REPLY_MESSAGE: ${{ inputs.line_default_reply_message }}
-          INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
-          VAR_LINE_BOT_ID: ${{ vars.LINE_BOT_ID }}
-          VAR_LINE_CHANNEL_ID: ${{ vars.LINE_CHANNEL_ID }}
-        run: |
-          set -euo pipefail
-
-          resolve_required() {
-            local input_value="$1"
-            local fallback_value="$2"
-            local key="$3"
-            local value="${input_value}"
-            if [[ -z "${value}" ]]; then
-              value="${fallback_value}"
-            fi
-            if [[ -z "${value}" ]]; then
-              echo "::error::${key} 缺少值，請在部署時輸入或先寫入 repo variable"
-              exit 1
-            fi
-            printf '%s' "${value}"
-          }
-
-          LINE_BOT_ID="$(resolve_required "${INPUT_LINE_BOT_ID}" "${VAR_LINE_BOT_ID}" "LINE_BOT_ID")"
-          LINE_CHANNEL_ID="$(resolve_required "${INPUT_LINE_CHANNEL_ID}" "${VAR_LINE_CHANNEL_ID}" "LINE_CHANNEL_ID")"
-
-          {
-            echo "line_bot_id=${LINE_BOT_ID}"
-            echo "line_channel_id=${LINE_CHANNEL_ID}"
-            echo "issue_number=${INPUT_ISSUE_NUMBER}"
-            echo 'line_default_reply_message<<EOF'
-            printf '%s\n' "${INPUT_LINE_DEFAULT_REPLY_MESSAGE}"
-            echo 'EOF'
-          } >> "${GITHUB_OUTPUT}"
-
-      - name: 同步 LINE Bot 設定到 GitHub Variables
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.CLAW_SYS_GITHUB_TOKEN || github.token }}
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const variables = {
-              LINE_BOT_ID: `${{ steps.resolve_line_config.outputs.line_bot_id }}`,
-              LINE_CHANNEL_ID: `${{ steps.resolve_line_config.outputs.line_channel_id }}`,
-            };
-
-            for (const [name, value] of Object.entries(variables)) {
-              try {
-                await github.rest.actions.updateRepoVariable({ owner, repo, name, value });
-              } catch (error) {
-                if (error.status !== 404) throw error;
-                await github.rest.actions.createRepoVariable({ owner, repo, name, value });
-              }
-            }
-
       - name: 建立 linebotworker label
         uses: actions/github-script@v7
         with:
@@ -262,12 +200,12 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           WORKER_NAME: ${{ steps.worker_name.outputs.worker_name }}
-          ISSUE_NUMBER: ${{ steps.resolve_line_config.outputs.issue_number }}
-          LINE_BOT_ID: ${{ steps.resolve_line_config.outputs.line_bot_id }}
-          LINE_CHANNEL_ID: ${{ steps.resolve_line_config.outputs.line_channel_id }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          LINE_BOT_ID: ${{ inputs.line_bot_id }}
+          LINE_CHANNEL_ID: ${{ inputs.line_bot_channel_id }}
           LINE_CHANNEL_SECRET: ${{ secrets.LINE_CHANNEL_SECRET }}
           LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
-          LINE_DEFAULT_REPLY_MESSAGE: ${{ steps.resolve_line_config.outputs.line_default_reply_message }}
+          LINE_DEFAULT_REPLY_MESSAGE: ${{ inputs.line_default_reply_message }}
           DEFAULT_UTC_OFFSET: ${{ inputs.default_utc_offset }}
           GITHUB_OWNER: ${{ github.repository_owner }}
           GITHUB_REPO: ${{ github.event.repository.name }}
@@ -348,10 +286,10 @@ jobs:
         shell: bash
         env:
           WORKER_NAME: ${{ steps.worker_name.outputs.worker_name }}
-          LINE_BOT_ID: ${{ steps.resolve_line_config.outputs.line_bot_id }}
-          LINE_CHANNEL_ID: ${{ steps.resolve_line_config.outputs.line_channel_id }}
+          LINE_BOT_ID: ${{ inputs.line_bot_id }}
+          LINE_CHANNEL_ID: ${{ inputs.line_bot_channel_id }}
           WORKER_URL: ${{ steps.deploy.outputs.deployment-url }}
-          ISSUE_NUMBER: ${{ steps.resolve_line_config.outputs.issue_number }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
         run: |
           WEBHOOK_URL="${WORKER_URL}/line/webhook"
           {
@@ -364,7 +302,7 @@ jobs:
             echo "| LINE Webhook URL | \`${WEBHOOK_URL}\` |"
             echo "| LINE Bot ID | \`${LINE_BOT_ID}\` |"
             echo "| LINE Bot Channel ID | \`${LINE_CHANNEL_ID}\` |"
-            echo "| Issue 綁定模式 | ${{ steps.resolve_line_config.outputs.issue_number != '' && 'fixed' || 'dynamic-by-source' }} |"
+            echo "| Issue 綁定模式 | ${{ inputs.issue_number != '' && 'fixed' || 'dynamic-by-source' }} |"
             echo "| 固定 Issue | ${ISSUE_NUMBER:-_dynamic_} |"
             echo "| DEFAULT_UTC_OFFSET | ${{ inputs.default_utc_offset }} |"
             echo ""

--- a/templates/line-bot/.github/workflows/install-line-bot.yml
+++ b/templates/line-bot/.github/workflows/install-line-bot.yml
@@ -1,4 +1,4 @@
-name: '🤖 安裝 LINE Bot'
+name: '🤖 安裝 LINE Bot Worker'
 
 on:
   workflow_dispatch:
@@ -25,7 +25,7 @@ on:
         default: "+08:00"
         type: string
 
-run-name: "🚀 安裝 LINEBotWorker - ${{ inputs.line_bot_id }}"
+run-name: "🚀 安裝 LINE Bot Worker - ${{ inputs.line_bot_id }}"
 
 permissions:
   contents: read
@@ -37,11 +37,29 @@ concurrency:
 
 jobs:
   deploy:
-    name: '🤖 安裝 LINE Bot'
+    name: '🤖 安裝 LINE Bot Worker'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
     steps:
+      - name: 驗證必要 Secrets
+        shell: bash
+        env:
+          LINE_CHANNEL_SECRET: ${{ secrets.LINE_CHANNEL_SECRET }}
+          LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          MISSING=()
+          [[ -z "${LINE_CHANNEL_SECRET}" ]] && MISSING+=("LINE_CHANNEL_SECRET")
+          [[ -z "${LINE_CHANNEL_ACCESS_TOKEN}" ]] && MISSING+=("LINE_CHANNEL_ACCESS_TOKEN")
+          if [[ ${#MISSING[@]} -gt 0 ]]; then
+            echo "::error::缺少必要的 GitHub Actions Secrets: ${MISSING[*]}（請先透過 /templates 安裝範本或手動設定）"
+            exit 1
+          fi
+
       - name: Checkout LINEBotWorker source
         uses: actions/checkout@v4
         with:
@@ -88,13 +106,9 @@ jobs:
         id: d1
         shell: bash
         working-directory: template-source/workers/line-bot
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          WORKER_NAME: ${{ steps.worker_name.outputs.worker_name }}
         run: |
           set -euo pipefail
-          DB_NAME="${WORKER_NAME}-db"
+          DB_NAME="${{ steps.worker_name.outputs.worker_name }}-db"
 
           # 嘗試取得現有 D1 資料庫
           EXISTING=$(bunx wrangler d1 list --json 2>/dev/null | node -e "
@@ -120,31 +134,19 @@ jobs:
       - name: 注入 D1 database_id 到 wrangler.jsonc
         shell: bash
         working-directory: template-source/workers/line-bot
-        env:
-          DATABASE_ID: ${{ steps.d1.outputs.database_id }}
-          WORKER_NAME: ${{ steps.worker_name.outputs.worker_name }}
         run: |
           set -euo pipefail
-          DB_NAME="${WORKER_NAME}-db"
-          node -e "
-            const fs = require('fs');
-            let content = fs.readFileSync('wrangler.jsonc', 'utf8');
-            content = content.replace(/\"database_name\":\s*\"line-bot-db\"/, '\"database_name\": \"'+'${DB_NAME}'+'\"');
-            content = content.replace(/\"database_id\":\s*\"PLACEHOLDER\"/, '\"database_id\": \"'+'${DATABASE_ID}'+'\"');
-            fs.writeFileSync('wrangler.jsonc', content);
-          "
+          DB_NAME="${{ steps.worker_name.outputs.worker_name }}-db"
+          DATABASE_ID="${{ steps.d1.outputs.database_id }}"
+          sed -i "s|\"database_name\": \"line-bot-db\"|\"database_name\": \"${DB_NAME}\"|" wrangler.jsonc
+          sed -i "s|\"database_id\": \"PLACEHOLDER\"|\"database_id\": \"${DATABASE_ID}\"|" wrangler.jsonc
 
       - name: 執行 D1 Migration
         shell: bash
         working-directory: template-source/workers/line-bot
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          DATABASE_ID: ${{ steps.d1.outputs.database_id }}
-          WORKER_NAME: ${{ steps.worker_name.outputs.worker_name }}
         run: |
           set -euo pipefail
-          DB_NAME="${WORKER_NAME}-db"
+          DB_NAME="${{ steps.worker_name.outputs.worker_name }}-db"
           bunx wrangler d1 migrations apply "${DB_NAME}" --remote --config wrangler.jsonc
           echo "✅ D1 Migration 完成"
 
@@ -155,21 +157,6 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy ${{ steps.build.outputs.bundle_path }} --config template-source/workers/line-bot/wrangler.jsonc --name ${{ steps.worker_name.outputs.worker_name }}
-
-      - name: 驗證必要 Secrets
-        shell: bash
-        env:
-          LINE_CHANNEL_SECRET: ${{ secrets.LINE_CHANNEL_SECRET }}
-          LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          MISSING=()
-          [[ -z "${LINE_CHANNEL_SECRET}" ]] && MISSING+=("LINE_CHANNEL_SECRET")
-          [[ -z "${LINE_CHANNEL_ACCESS_TOKEN}" ]] && MISSING+=("LINE_CHANNEL_ACCESS_TOKEN")
-          if [[ ${#MISSING[@]} -gt 0 ]]; then
-            echo "::error::缺少必要的 GitHub Actions Secrets: ${MISSING[*]}（請先透過 /templates 安裝範本或手動設定）"
-            exit 1
-          fi
 
       - name: 建立 linebotworker label
         uses: actions/github-script@v7
@@ -188,7 +175,7 @@ jobs:
                 owner,
                 repo,
                 name,
-                color: '1D76DB',
+                color: '06C755',
                 description: 'Issues created by LINEBotWorker',
               });
             }

--- a/templates/line-bot/.github/workflows/install-line-bot.yml
+++ b/templates/line-bot/.github/workflows/install-line-bot.yml
@@ -1,4 +1,4 @@
-name: install-line-bot
+name: '🤖 安裝 LINE Bot'
 
 on:
   workflow_dispatch:
@@ -13,14 +13,6 @@ on:
         type: string
       line_bot_channel_id:
         description: LINE Bot Channel ID
-        required: true
-        type: string
-      line_channel_secret:
-        description: LINE Bot Channel secret
-        required: true
-        type: string
-      line_channel_access_token:
-        description: LINE Bot Channel access token
         required: true
         type: string
       line_default_reply_message:
@@ -44,6 +36,7 @@ concurrency:
 
 jobs:
   deploy:
+    name: '🤖 安裝 LINE Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -51,7 +44,8 @@ jobs:
       - name: Checkout LINEBotWorker source
         uses: actions/checkout@v4
         with:
-          repository: duotify/GitHubClawSkills
+          repository: duotify/GitHubClawToolkit
+          ref: fix/line-bot
           path: template-source
           sparse-checkout: |
             workers/line-bot
@@ -89,6 +83,70 @@ jobs:
           WORKER_NAME="$(node ./scripts/resolve-worker-name.mjs "${RAW_WORKER_NAME}")"
           echo "worker_name=${WORKER_NAME}" >> "${GITHUB_OUTPUT}"
 
+      - name: 建立 D1 資料庫
+        id: d1
+        shell: bash
+        working-directory: template-source/workers/line-bot
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WORKER_NAME: ${{ steps.worker_name.outputs.worker_name }}
+        run: |
+          set -euo pipefail
+          DB_NAME="${WORKER_NAME}-db"
+
+          # 嘗試取得現有 D1 資料庫
+          EXISTING=$(bunx wrangler d1 list --json 2>/dev/null | node -e "
+            const data = require('fs').readFileSync('/dev/stdin','utf8');
+            const dbs = JSON.parse(data);
+            const found = dbs.find(d => d.name === '${DB_NAME}');
+            if (found) console.log(found.uuid);
+          " || true)
+
+          if [[ -n "${EXISTING}" ]]; then
+            echo "✅ D1 資料庫已存在: ${DB_NAME} (${EXISTING})"
+            echo "database_id=${EXISTING}" >> "${GITHUB_OUTPUT}"
+          else
+            CREATE_OUTPUT=$(bunx wrangler d1 create "${DB_NAME}" --json 2>/dev/null)
+            DB_ID=$(echo "${CREATE_OUTPUT}" | node -e "
+              const data = require('fs').readFileSync('/dev/stdin','utf8');
+              console.log(JSON.parse(data).uuid);
+            ")
+            echo "✅ D1 資料庫已建立: ${DB_NAME} (${DB_ID})"
+            echo "database_id=${DB_ID}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: 注入 D1 database_id 到 wrangler.jsonc
+        shell: bash
+        working-directory: template-source/workers/line-bot
+        env:
+          DATABASE_ID: ${{ steps.d1.outputs.database_id }}
+          WORKER_NAME: ${{ steps.worker_name.outputs.worker_name }}
+        run: |
+          set -euo pipefail
+          DB_NAME="${WORKER_NAME}-db"
+          node -e "
+            const fs = require('fs');
+            let content = fs.readFileSync('wrangler.jsonc', 'utf8');
+            content = content.replace(/\"database_name\":\s*\"line-bot-db\"/, '\"database_name\": \"'+'${DB_NAME}'+'\"');
+            content = content.replace(/\"database_id\":\s*\"PLACEHOLDER\"/, '\"database_id\": \"'+'${DATABASE_ID}'+'\"');
+            fs.writeFileSync('wrangler.jsonc', content);
+          "
+
+      - name: 執行 D1 Migration
+        shell: bash
+        working-directory: template-source/workers/line-bot
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DATABASE_ID: ${{ steps.d1.outputs.database_id }}
+          WORKER_NAME: ${{ steps.worker_name.outputs.worker_name }}
+        run: |
+          set -euo pipefail
+          DB_NAME="${WORKER_NAME}-db"
+          bunx wrangler d1 migrations apply "${DB_NAME}" --remote --config wrangler.jsonc
+          echo "✅ D1 Migration 完成"
+
       - name: 部署 LINEBotWorker
         id: deploy
         uses: cloudflare/wrangler-action@v3
@@ -96,6 +154,21 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy ${{ steps.build.outputs.bundle_path }} --config template-source/workers/line-bot/wrangler.jsonc --name ${{ steps.worker_name.outputs.worker_name }}
+
+      - name: 驗證必要 Secrets
+        shell: bash
+        env:
+          LINE_CHANNEL_SECRET: ${{ secrets.LINE_CHANNEL_SECRET }}
+          LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          MISSING=()
+          [[ -z "${LINE_CHANNEL_SECRET}" ]] && MISSING+=("LINE_CHANNEL_SECRET")
+          [[ -z "${LINE_CHANNEL_ACCESS_TOKEN}" ]] && MISSING+=("LINE_CHANNEL_ACCESS_TOKEN")
+          if [[ ${#MISSING[@]} -gt 0 ]]; then
+            echo "::error::缺少必要的 GitHub Actions Secrets: ${MISSING[*]}（請先透過 /templates 安裝範本或手動設定）"
+            exit 1
+          fi
 
       - name: 同步 LINEBotWorker secrets
         shell: bash
@@ -107,8 +180,8 @@ jobs:
           ISSUE_NUMBER: ${{ inputs.issue_number }}
           LINE_BOT_ID: ${{ inputs.line_bot_id }}
           LINE_CHANNEL_ID: ${{ inputs.line_bot_channel_id }}
-          LINE_CHANNEL_SECRET: ${{ inputs.line_channel_secret }}
-          LINE_CHANNEL_ACCESS_TOKEN: ${{ inputs.line_channel_access_token }}
+          LINE_CHANNEL_SECRET: ${{ secrets.LINE_CHANNEL_SECRET }}
+          LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
           LINE_DEFAULT_REPLY_MESSAGE: ${{ inputs.line_default_reply_message }}
           DEFAULT_UTC_OFFSET: ${{ inputs.default_utc_offset }}
           GITHUB_OWNER: ${{ github.repository_owner }}
@@ -150,6 +223,42 @@ jobs:
           put_secret "LINE_CHANNEL_ACCESS_TOKEN" "${LINE_CHANNEL_ACCESS_TOKEN}"
           put_optional_secret "LINE_DEFAULT_REPLY_MESSAGE" "${LINE_DEFAULT_REPLY_MESSAGE}"
           put_secret "DEFAULT_UTC_OFFSET" "${DEFAULT_UTC_OFFSET}"
+
+      - name: 設定 LINE Webhook URL
+        shell: bash
+        env:
+          LINE_CHANNEL_ACCESS_TOKEN: ${{ secrets.LINE_CHANNEL_ACCESS_TOKEN }}
+          WORKER_URL: ${{ steps.deploy.outputs.deployment-url }}
+        run: |
+          set -euo pipefail
+          WEBHOOK_URL="${WORKER_URL}/line/webhook"
+
+          HTTP_CODE=$(curl -s -o /tmp/set-webhook-response.json -w "%{http_code}" \
+            -X PUT "https://api.line.me/v2/bot/channel/webhook/endpoint" \
+            -H "Authorization: Bearer ${LINE_CHANNEL_ACCESS_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"endpoint\": \"${WEBHOOK_URL}\"}")
+
+          if [[ "${HTTP_CODE}" -ne 200 ]]; then
+            echo "::error::設定 LINE Webhook 失敗（HTTP ${HTTP_CODE}）"
+            cat /tmp/set-webhook-response.json || true
+            exit 1
+          fi
+          echo "✅ LINE Webhook URL 已設定: ${WEBHOOK_URL}"
+
+          VERIFY_BODY=$(curl -s -w "\n%{http_code}" \
+            -X POST "https://api.line.me/v2/bot/channel/webhook/test" \
+            -H "Authorization: Bearer ${LINE_CHANNEL_ACCESS_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"endpoint\": \"${WEBHOOK_URL}\"}")
+
+          VERIFY_CODE=$(echo "${VERIFY_BODY}" | tail -1)
+          if [[ "${VERIFY_CODE}" -ne 200 ]]; then
+            echo "::warning::LINE Webhook 驗證失敗（HTTP ${VERIFY_CODE}），請手動確認"
+          else
+            echo "✅ LINE Webhook 驗證成功"
+          fi
+
       - name: 寫入摘要
         shell: bash
         env:
@@ -159,6 +268,7 @@ jobs:
           WORKER_URL: ${{ steps.deploy.outputs.deployment-url }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
         run: |
+          WEBHOOK_URL="${WORKER_URL}/line/webhook"
           {
             echo "### ✅ LINEBotWorker 建立摘要"
             echo ""
@@ -166,9 +276,12 @@ jobs:
             echo "|---|---|"
             echo "| Worker 名稱 | \`${WORKER_NAME}\` |"
             echo "| Worker URL | [${WORKER_URL}](${WORKER_URL}) |"
+            echo "| LINE Webhook URL | \`${WEBHOOK_URL}\` |"
             echo "| LINE Bot ID | \`${LINE_BOT_ID}\` |"
             echo "| LINE Bot Channel ID | \`${LINE_CHANNEL_ID}\` |"
             echo "| Issue 綁定模式 | ${{ inputs.issue_number != '' && 'fixed' || 'dynamic-by-source' }} |"
             echo "| 固定 Issue | ${ISSUE_NUMBER:-_dynamic_} |"
             echo "| DEFAULT_UTC_OFFSET | ${{ inputs.default_utc_offset }} |"
+            echo ""
+            echo "> ⚠️ **請至 [LINE Developers Console](https://developers.line.biz/console/channel/${LINE_CHANNEL_ID}/messaging-api) 確認已開啟「Use webhook」開關**（LINE API 不支援自動開啟）"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/workers/line-bot/migrations/0001_create_source_issues.sql
+++ b/workers/line-bot/migrations/0001_create_source_issues.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS source_issues (
+  source_key TEXT PRIMARY KEY,
+  status TEXT NOT NULL DEFAULT 'creating',
+  issue_number INTEGER,
+  issue_url TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);

--- a/workers/line-bot/src/application/line/event-processor.js
+++ b/workers/line-bot/src/application/line/event-processor.js
@@ -1,9 +1,15 @@
 import {
   createIssue,
   createIssueComment,
-  findIssueBySourceKey,
   uploadFileToRepo,
 } from '../../infrastructure/github/line-github-service.js';
+import {
+  claimSourceKey,
+  findSourceIssue,
+  bindSourceIssue,
+  deleteSourceIssue,
+  waitForSourceIssue,
+} from '../../infrastructure/d1/source-issue-store.js';
 import {
   canReplyToLineEvent,
   getLineMessageContent,
@@ -86,30 +92,54 @@ async function resolveTargetIssue(config, repo, sourceInfo, sourceContext) {
     };
   }
 
-  const existingIssue = await findIssueBySourceKey(
-    config.github,
-    repo,
-    sourceInfo.key,
-  );
+  const db = config.db;
+  if (!db) {
+    throw new Error('D1 database binding (DB) is required for dynamic issue binding.');
+  }
 
-  if (existingIssue?.number) {
+  const existing = await findSourceIssue(db, sourceInfo.key);
+  if (existing?.status === 'ready' && existing.issue_number) {
     return {
-      issueNumber: existingIssue.number,
-      issueUrl:
-        existingIssue.html_url || buildIssueUrl(repo, existingIssue.number),
+      issueNumber: existing.issue_number,
+      issueUrl: existing.issue_url || buildIssueUrl(repo, existing.issue_number),
       issueState: 'existing',
     };
   }
 
+  const inserted = await claimSourceKey(db, sourceInfo.key);
+
+  if (inserted) {
+    return await createAndBindIssue(config, repo, sourceInfo, sourceContext);
+  }
+
+  // 沒搶到鎖，等別人建好
+  const waited = await waitForSourceIssue(db, sourceInfo.key);
+
+  if (waited?.status === 'ready' && waited.issue_number) {
+    return {
+      issueNumber: waited.issue_number,
+      issueUrl: waited.issue_url || buildIssueUrl(repo, waited.issue_number),
+      issueState: 'existing',
+    };
+  }
+
+  throw new Error(`Timed out waiting for issue creation for source: ${sourceInfo.key}`);
+}
+
+async function createAndBindIssue(config, repo, sourceInfo, sourceContext) {
   const issueDefinition = buildSourceIssueDefinition(sourceInfo, sourceContext);
+
   const createdIssue = await createIssue(config.github, repo, {
     title: issueDefinition.title,
     body: issueDefinition.body,
   });
 
+  const issueUrl = createdIssue.html_url || buildIssueUrl(repo, createdIssue.number);
+  await bindSourceIssue(config.db, sourceInfo.key, createdIssue.number, issueUrl);
+
   return {
     issueNumber: createdIssue.number,
-    issueUrl: createdIssue.html_url || buildIssueUrl(repo, createdIssue.number),
+    issueUrl,
     issueState: 'created',
   };
 }
@@ -212,6 +242,11 @@ async function maybeReplyWithDefaultMessage(config, event) {
   return replyText;
 }
 
+function isIssueNotFoundError(error) {
+  const msg = error?.message || '';
+  return msg.includes('Not Found') || msg.includes('status 404') || msg.includes('status 410');
+}
+
 export async function processEvent(config, event) {
   const sourceInfo = getSourceInfo(event);
   const targetRepo = {
@@ -225,13 +260,13 @@ export async function processEvent(config, event) {
   }
 
   const sourceContext = await resolveSourceContext(config, sourceInfo);
-  const issueBinding = await resolveTargetIssue(
+  let issueBinding = await resolveTargetIssue(
     config,
     targetRepo,
     sourceInfo,
     sourceContext,
   );
-  const eventContext = await buildEventContext(
+  let eventContext = await buildEventContext(
     config,
     targetRepo,
     event,
@@ -239,14 +274,43 @@ export async function processEvent(config, event) {
     sourceContext.senderName,
   );
 
-  await maybeReplyWithDefaultMessage(config, event);
+  // LINE 回覆失敗不影響 comment 寫入
+  try {
+    await maybeReplyWithDefaultMessage(config, event);
+  } catch (error) {
+    console.warn('LINE reply failed (non-blocking)', {
+      webhookEventId: event?.webhookEventId,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
 
-  await createIssueComment(
-    config.github,
-    targetRepo,
-    issueBinding.issueNumber,
-    buildCommentBody(event, sourceInfo, eventContext),
-  );
+  try {
+    await createIssueComment(
+      config.github,
+      targetRepo,
+      issueBinding.issueNumber,
+      buildCommentBody(event, sourceInfo, eventContext),
+    );
+  } catch (error) {
+    // Issue 被刪除了 → 清除 D1 紀錄，重新建立 Issue
+    if (isIssueNotFoundError(error) && config.db) {
+      console.warn('Issue not found, clearing D1 record and retrying', {
+        issueNumber: issueBinding.issueNumber,
+        sourceKey: sourceInfo.key,
+      });
+      await deleteSourceIssue(config.db, sourceInfo.key);
+      issueBinding = await resolveTargetIssue(config, targetRepo, sourceInfo, sourceContext);
+      eventContext = await buildEventContext(config, targetRepo, event, issueBinding, sourceContext.senderName);
+      await createIssueComment(
+        config.github,
+        targetRepo,
+        issueBinding.issueNumber,
+        buildCommentBody(event, sourceInfo, eventContext),
+      );
+    } else {
+      throw error;
+    }
+  }
 
   return {
     commented: true,

--- a/workers/line-bot/src/application/line/event-processor.js
+++ b/workers/line-bot/src/application/line/event-processor.js
@@ -132,15 +132,21 @@ async function resolveTargetIssue(config, repo, sourceInfo, sourceContext) {
 async function createAndBindIssue(config, repo, sourceInfo, sourceContext) {
   const issueDefinition = buildSourceIssueDefinition(sourceInfo, sourceContext);
 
-  await ensureLabels(config.github, repo, issueDefinition.labels, {
-    description: 'Auto-created by LINEBotWorker',
-  });
+  let createdIssue;
+  try {
+    await ensureLabels(config.github, repo, issueDefinition.labels, {
+      description: 'Auto-created by LINEBotWorker',
+    });
 
-  const createdIssue = await createIssue(config.github, repo, {
-    title: issueDefinition.title,
-    body: issueDefinition.body,
-    labels: issueDefinition.labels,
-  });
+    createdIssue = await createIssue(config.github, repo, {
+      title: issueDefinition.title,
+      body: issueDefinition.body,
+      labels: issueDefinition.labels,
+    });
+  } catch (error) {
+    await deleteSourceIssue(config.db, sourceInfo.key);
+    throw error;
+  }
 
   const issueUrl = createdIssue.html_url || buildIssueUrl(repo, createdIssue.number);
   await bindSourceIssue(config.db, sourceInfo.key, createdIssue.number, issueUrl);
@@ -272,8 +278,11 @@ async function maybeReplyWithDefaultMessage(config, event) {
 }
 
 function isIssueNotFoundError(error) {
+  const status = error?.status ?? error?.statusCode ?? error?.response?.status;
+  if (status === 404 || status === 410) return true;
+
   const msg = error?.message || '';
-  return msg.includes('Not Found') || msg.includes('status 404') || msg.includes('status 410');
+  return msg.includes('Not Found') || msg.includes('Gone') || msg.includes('status 404') || msg.includes('status 410');
 }
 
 export async function processEvent(config, event) {

--- a/workers/line-bot/src/application/line/event-processor.js
+++ b/workers/line-bot/src/application/line/event-processor.js
@@ -1,6 +1,7 @@
 import {
   createIssue,
   createIssueComment,
+  ensureLabels,
   getIssue,
   updateIssue,
   uploadFileToRepo,
@@ -131,9 +132,14 @@ async function resolveTargetIssue(config, repo, sourceInfo, sourceContext) {
 async function createAndBindIssue(config, repo, sourceInfo, sourceContext) {
   const issueDefinition = buildSourceIssueDefinition(sourceInfo, sourceContext);
 
+  await ensureLabels(config.github, repo, issueDefinition.labels, {
+    description: 'Auto-created by LINEBotWorker',
+  });
+
   const createdIssue = await createIssue(config.github, repo, {
     title: issueDefinition.title,
     body: issueDefinition.body,
+    labels: issueDefinition.labels,
   });
 
   const issueUrl = createdIssue.html_url || buildIssueUrl(repo, createdIssue.number);

--- a/workers/line-bot/src/application/line/event-processor.js
+++ b/workers/line-bot/src/application/line/event-processor.js
@@ -1,6 +1,8 @@
 import {
   createIssue,
   createIssueComment,
+  getIssue,
+  updateIssue,
   uploadFileToRepo,
 } from '../../infrastructure/github/line-github-service.js';
 import {
@@ -144,6 +146,27 @@ async function createAndBindIssue(config, repo, sourceInfo, sourceContext) {
   };
 }
 
+async function syncSourceIssueTitle(config, repo, issueBinding, sourceInfo, sourceContext) {
+  if (
+    issueBinding.issueState === 'fixed' ||
+    issueBinding.issueState === 'created' ||
+    !Number.isInteger(issueBinding.issueNumber) ||
+    !sourceContext?.sourceDisplayName
+  ) {
+    return;
+  }
+
+  const desiredTitle = buildSourceIssueDefinition(sourceInfo, sourceContext).title;
+  const currentIssue = await getIssue(config.github, repo, issueBinding.issueNumber);
+  if (currentIssue?.title === desiredTitle) {
+    return;
+  }
+
+  await updateIssue(config.github, repo, issueBinding.issueNumber, {
+    title: desiredTitle,
+  });
+}
+
 async function persistMediaMessage(config, repo, issueNumber, event) {
   if (!issueNumber || !isMediaMessageEvent(event)) {
     return {
@@ -266,6 +289,17 @@ export async function processEvent(config, event) {
     sourceInfo,
     sourceContext,
   );
+
+  try {
+    await syncSourceIssueTitle(config, targetRepo, issueBinding, sourceInfo, sourceContext);
+  } catch (error) {
+    console.warn('Failed to sync LINE source issue title', {
+      issueNumber: issueBinding.issueNumber,
+      sourceKey: sourceInfo.key,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+  }
+
   let eventContext = await buildEventContext(
     config,
     targetRepo,

--- a/workers/line-bot/src/domain/line/issue-binding.js
+++ b/workers/line-bot/src/domain/line/issue-binding.js
@@ -49,6 +49,7 @@ export function buildSourceIssueDefinition(sourceInfo, context = {}) {
       'Reinstalling the worker should reuse this issue when the source key matches.',
     ].filter(Boolean).join('\n'),
     labels: [
+      'linebotworker',
       'line',
       `line:${sourceInfo.type || 'unknown'}`,
     ],

--- a/workers/line-bot/src/domain/line/issue-binding.js
+++ b/workers/line-bot/src/domain/line/issue-binding.js
@@ -48,10 +48,6 @@ export function buildSourceIssueDefinition(sourceInfo, context = {}) {
       '',
       'Reinstalling the worker should reuse this issue when the source key matches.',
     ].filter(Boolean).join('\n'),
-    labels: [
-      'linebotworker',
-      'line',
-      `line:${sourceInfo.type || 'unknown'}`,
-    ],
+    labels: ['linebotworker'],
   };
 }

--- a/workers/line-bot/src/infrastructure/config/line-config.js
+++ b/workers/line-bot/src/infrastructure/config/line-config.js
@@ -121,5 +121,6 @@ export function getConfig(env) {
       workerName,
     },
     assistant: createAssistantConfig(env),
+    db: env.DB || null,
   };
 }

--- a/workers/line-bot/src/infrastructure/d1/source-issue-store.js
+++ b/workers/line-bot/src/infrastructure/d1/source-issue-store.js
@@ -1,0 +1,64 @@
+const POLL_INTERVAL_MS = 500;
+const MAX_POLL_RETRIES = 60;
+
+function nowMs() {
+  return Date.now();
+}
+
+export async function findSourceIssue(db, sourceKey) {
+  const row = await db
+    .prepare('SELECT source_key, status, issue_number, issue_url FROM source_issues WHERE source_key = ?')
+    .bind(sourceKey)
+    .first();
+  return row || null;
+}
+
+export async function claimSourceKey(db, sourceKey) {
+  const now = nowMs();
+
+  const result = await db
+    .prepare(
+      'INSERT OR IGNORE INTO source_issues (source_key, status, created_at, updated_at) VALUES (?, ?, ?, ?)',
+    )
+    .bind(sourceKey, 'creating', now, now)
+    .run();
+
+  return result.meta?.changes === 1;
+}
+
+export async function bindSourceIssue(db, sourceKey, issueNumber, issueUrl) {
+  await db
+    .prepare(
+      'UPDATE source_issues SET status = ?, issue_number = ?, issue_url = ?, updated_at = ? WHERE source_key = ?',
+    )
+    .bind('ready', issueNumber, issueUrl, nowMs(), sourceKey)
+    .run();
+}
+
+export async function deleteSourceIssue(db, sourceKey) {
+  await db
+    .prepare('DELETE FROM source_issues WHERE source_key = ?')
+    .bind(sourceKey)
+    .run();
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitForSourceIssue(db, sourceKey, maxRetries = MAX_POLL_RETRIES) {
+  for (let i = 0; i < maxRetries; i++) {
+    await sleep(POLL_INTERVAL_MS);
+
+    const row = await findSourceIssue(db, sourceKey);
+    if (!row) {
+      return null;
+    }
+
+    if (row.status === 'ready' && row.issue_number) {
+      return row;
+    }
+  }
+
+  return null;
+}

--- a/workers/line-bot/src/infrastructure/github/line-github-service.js
+++ b/workers/line-bot/src/infrastructure/github/line-github-service.js
@@ -5,5 +5,6 @@ export {
   findIssueBySourceKey,
   getIssue,
   listIssueComments,
+  updateIssue,
   uploadFileToRepo,
 } from './github-issues-client.js';

--- a/workers/line-bot/src/presentation/http/line-bot-worker.js
+++ b/workers/line-bot/src/presentation/http/line-bot-worker.js
@@ -65,7 +65,8 @@ app.post('/line/webhook', async (c) => {
             webhookEventId: event?.webhookEventId,
             source: event?.source,
           });
-        })),
+        }),
+      ),
     ),
   );
 

--- a/workers/line-bot/test/worker.test.js
+++ b/workers/line-bot/test/worker.test.js
@@ -515,6 +515,14 @@ test('direct user message reuses the existing source issue when ISSUE_NUMBER is 
       return jsonResponse(200, { displayName: 'Charlie' });
     }
 
+    if (String(url) === issueUrl(dynamicIssueNumber) && init.method === 'GET') {
+      return jsonResponse(200, {
+        number: dynamicIssueNumber,
+        title: '[LINE][user] Charlie (Udirect123)',
+        html_url: dynamicIssueUrl,
+      });
+    }
+
     if (String(url) === issueCommentUrl(dynamicIssueNumber) && init.method === 'POST') {
       return jsonResponse(201, {
         id: 1902,
@@ -670,6 +678,104 @@ test('group message creates a unique source issue when ISSUE_NUMBER is omitted',
     );
     assert.match(commentPayload.body, /- Group ID: Cgroup999/);
     assert.match(commentPayload.body, /- Sender: Alice/);
+  } finally {
+    fetchStub.restore();
+  }
+});
+
+test('group message updates the existing dynamic issue title when the group name changes', async () => {
+  const dynamicIssueNumber = 621;
+  const dynamicIssueUrl = `https://github.com/${DEFAULT_REPO_FULL_NAME}/issues/${dynamicIssueNumber}`;
+  const oldTitle = '[LINE][group] Support Squad (Cgroup999)';
+  const newTitle = '[LINE][group] Renamed Squad (Cgroup999)';
+  const fetchStub = installFetchStub(async (url, init = {}) => {
+    if (isLineGroupSummaryUrl(url)) {
+      return jsonResponse(200, { groupName: 'Renamed Squad' });
+    }
+
+    if (isLineProfileUrl(url)) {
+      return jsonResponse(200, { displayName: 'Alice' });
+    }
+
+    if (String(url) === issueUrl(dynamicIssueNumber) && init.method === 'GET') {
+      return jsonResponse(200, {
+        number: dynamicIssueNumber,
+        title: oldTitle,
+        html_url: dynamicIssueUrl,
+      });
+    }
+
+    if (String(url) === issueUrl(dynamicIssueNumber) && init.method === 'PATCH') {
+      const payload = JSON.parse(init.body);
+      assert.equal(payload.title, newTitle);
+      return jsonResponse(200, {
+        number: dynamicIssueNumber,
+        title: payload.title,
+        html_url: dynamicIssueUrl,
+      });
+    }
+
+    if (String(url) === issueCommentUrl(dynamicIssueNumber) && init.method === 'POST') {
+      return jsonResponse(201, {
+        id: 1904,
+        html_url: `${dynamicIssueUrl}#issuecomment-1904`,
+      });
+    }
+
+    throw new Error(`Unexpected fetch call: ${url}`);
+  });
+
+  try {
+    const ctx = createContext();
+    const mockDB = createMockD1([
+      {
+        source_key: 'group:Cgroup999',
+        status: 'ready',
+        issue_number: dynamicIssueNumber,
+        issue_url: dynamicIssueUrl,
+      },
+    ]);
+    const { env, request } = await createSignedRequest(
+      '/line/webhook',
+      {
+        events: [
+          {
+            type: 'message',
+            webhookEventId: 'event-group-dynamic-rename-1',
+            timestamp: 1_710_000_010_000,
+            source: {
+              type: 'group',
+              groupId: 'Cgroup999',
+              userId: 'Ualice',
+            },
+            message: {
+              id: '987654323',
+              type: 'text',
+              text: 'Title sync check',
+            },
+          },
+        ],
+      },
+      {
+        ISSUE_NUMBER: undefined,
+        DB: mockDB,
+      },
+    );
+
+    const response = await worker.fetch(request, env, ctx);
+    assert.equal(response.status, 200);
+
+    await Promise.all(ctx.promises);
+
+    const updateIssueCall = fetchStub.calls.find(
+      (call) => String(call.url) === issueUrl(dynamicIssueNumber) && call.init.method === 'PATCH',
+    );
+    assert.ok(updateIssueCall);
+
+    const commentCall = fetchStub.calls.find(
+      (call) => String(call.url) === issueCommentUrl(dynamicIssueNumber),
+    );
+    assert.ok(commentCall);
   } finally {
     fetchStub.restore();
   }

--- a/workers/line-bot/test/worker.test.js
+++ b/workers/line-bot/test/worker.test.js
@@ -172,6 +172,14 @@ function issueWorkspacePath(fileName, issueNumber = DEFAULT_ISSUE_NUMBER) {
   return `workspaces/issue-${issueNumber}/line/${fileName}`;
 }
 
+function repoLabelUrl(name, repoFullName = DEFAULT_REPO_FULL_NAME) {
+  return `https://api.github.com/repos/${repoFullName}/labels/${encodeURIComponent(name)}`;
+}
+
+function repoLabelsUrl(repoFullName = DEFAULT_REPO_FULL_NAME) {
+  return `https://api.github.com/repos/${repoFullName}/labels`;
+}
+
 async function createSignedRequest(path, payload, envOverrides = {}) {
   const env = createEnv(envOverrides);
   const body = JSON.stringify(payload);
@@ -607,6 +615,22 @@ test('group message creates a unique source issue when ISSUE_NUMBER is omitted',
       return jsonResponse(200, { displayName: 'Alice' });
     }
 
+    if (
+      [
+        repoLabelUrl('linebotworker'),
+        repoLabelUrl('line'),
+        repoLabelUrl('line:group'),
+      ].includes(String(url)) &&
+      init.method === 'GET'
+    ) {
+      return notFoundResponse();
+    }
+
+    if (String(url) === repoLabelsUrl() && init.method === 'POST') {
+      const payload = JSON.parse(init.body);
+      return jsonResponse(201, payload);
+    }
+
     if (String(url) === issueCreateUrl() && init.method === 'POST') {
       const payload = JSON.parse(init.body);
       assert.match(payload.title, /^\[LINE\]\[group\] Support Squad \(Cgroup999\)$/);
@@ -614,6 +638,7 @@ test('group message creates a unique source issue when ISSUE_NUMBER is omitted',
       assert.match(payload.body, /- Source key: group:Cgroup999/);
       assert.match(payload.body, /- Group ID: Cgroup999/);
       assert.match(payload.body, /- Source display name: Support Squad/);
+      assert.deepEqual(payload.labels, ['linebotworker', 'line', 'line:group']);
 
       return jsonResponse(201, {
         number: dynamicIssueNumber,

--- a/workers/line-bot/test/worker.test.js
+++ b/workers/line-bot/test/worker.test.js
@@ -1313,6 +1313,75 @@ test('worker uses configured default reply message for replyable events', async 
   }
 });
 
+test('worker still comments when the default LINE reply fails', async () => {
+  const originalWarn = console.warn;
+  console.warn = () => {};
+
+  const fetchStub = installFetchStub(async (url, init = {}) => {
+    if (isLineProfileUrl(url)) {
+      return jsonResponse(200, { displayName: 'Reply Failure User' });
+    }
+
+    if (isLineReplyUrl(url)) {
+      return jsonResponse(500, { message: 'Reply delivery failed' });
+    }
+
+    if (String(url) === issueCommentUrl() && init.method === 'POST') {
+      return jsonResponse(201, {
+        id: 911,
+        html_url: `${DEFAULT_ISSUE_URL}#issuecomment-911`,
+      });
+    }
+
+    throw new Error(`Unexpected fetch call: ${url}`);
+  });
+
+  try {
+    const ctx = createContext();
+    const { env, request } = await createSignedRequest(
+      '/line/webhook',
+      {
+        events: [
+          {
+            type: 'message',
+            webhookEventId: 'event-canned-failure-1',
+            timestamp: Date.now(),
+            replyToken: 'reply-token-canned-failure-1',
+            source: {
+              type: 'user',
+              userId: 'Ucanned-failure-1',
+            },
+            message: {
+              id: 'canned-msg-failure-1',
+              type: 'text',
+              text: 'reply should fail but comment should still be created',
+            },
+          },
+        ],
+      },
+      {
+        LINE_DEFAULT_REPLY_MESSAGE: '這是失敗測試用的預設回應',
+      },
+    );
+
+    const response = await worker.fetch(request, env, ctx);
+    assert.equal(response.status, 200);
+
+    await Promise.all(ctx.promises);
+
+    const replyCall = fetchStub.calls.find((call) => isLineReplyUrl(call.url));
+    assert.ok(replyCall);
+
+    const commentCall = fetchStub.calls.find(
+      (call) => String(call.url) === issueCommentUrl(),
+    );
+    assert.ok(commentCall);
+  } finally {
+    fetchStub.restore();
+    console.warn = originalWarn;
+  }
+});
+
 test('image upload permission error becomes a readable comment on the fixed issue', async () => {
   const fetchStub = installFetchStub(async (url, init = {}) => {
     if (isLineProfileUrl(url)) {

--- a/workers/line-bot/test/worker.test.js
+++ b/workers/line-bot/test/worker.test.js
@@ -10,6 +10,62 @@ const DEFAULT_ISSUE_NUMBER = 501;
 const DEFAULT_REPO_FULL_NAME = `${DEFAULT_OWNER}/${DEFAULT_REPO}`;
 const DEFAULT_ISSUE_URL = `https://github.com/${DEFAULT_REPO_FULL_NAME}/issues/${DEFAULT_ISSUE_NUMBER}`;
 
+function createMockD1(initialRows = []) {
+  const rows = new Map();
+  for (const row of initialRows) {
+    rows.set(row.source_key, { ...row });
+  }
+
+  function createStatement(sql, params = []) {
+    return {
+      bind(...args) {
+        return createStatement(sql, args);
+      },
+      async first() {
+        const key = params[0];
+        return rows.get(key) || null;
+      },
+      async run() {
+        if (sql.startsWith('INSERT OR IGNORE')) {
+          const key = params[0];
+          if (rows.has(key)) {
+            return { meta: { changes: 0 } };
+          }
+          rows.set(key, {
+            source_key: key,
+            status: params[1],
+            issue_number: null,
+            issue_url: null,
+            created_at: params[2],
+            updated_at: params[3],
+          });
+          return { meta: { changes: 1 } };
+        }
+        if (sql.startsWith('UPDATE')) {
+          const key = params[4];
+          const row = rows.get(key);
+          if (row) {
+            row.status = params[0];
+            row.issue_number = params[1];
+            row.issue_url = params[2];
+            row.updated_at = params[3];
+          }
+          return { meta: { changes: row ? 1 : 0 } };
+        }
+        if (sql.startsWith('DELETE')) {
+          const key = params[0];
+          const had = rows.has(key);
+          rows.delete(key);
+          return { meta: { changes: had ? 1 : 0 } };
+        }
+        return { meta: { changes: 0 } };
+      },
+    };
+  }
+
+  return { prepare: (sql) => createStatement(sql) };
+}
+
 function createEnv(overrides = {}) {
   return {
     CLAW_SYS_GITHUB_TOKEN: 'github-token',
@@ -459,17 +515,6 @@ test('direct user message reuses the existing source issue when ISSUE_NUMBER is 
       return jsonResponse(200, { displayName: 'Charlie' });
     }
 
-    if (String(url).includes('/search/issues?')) {
-      return jsonResponse(200, {
-        items: [
-          {
-            number: dynamicIssueNumber,
-            html_url: dynamicIssueUrl,
-          },
-        ],
-      });
-    }
-
     if (String(url) === issueCommentUrl(dynamicIssueNumber) && init.method === 'POST') {
       return jsonResponse(201, {
         id: 1902,
@@ -482,6 +527,14 @@ test('direct user message reuses the existing source issue when ISSUE_NUMBER is 
 
   try {
     const ctx = createContext();
+    const mockDB = createMockD1([
+      {
+        source_key: 'user:Udirect123',
+        status: 'ready',
+        issue_number: dynamicIssueNumber,
+        issue_url: dynamicIssueUrl,
+      },
+    ]);
     const { env, request } = await createSignedRequest(
       '/line/webhook',
       {
@@ -504,6 +557,7 @@ test('direct user message reuses the existing source issue when ISSUE_NUMBER is 
       },
       {
         ISSUE_NUMBER: undefined,
+        DB: mockDB,
       },
     );
 
@@ -545,10 +599,6 @@ test('group message creates a unique source issue when ISSUE_NUMBER is omitted',
       return jsonResponse(200, { displayName: 'Alice' });
     }
 
-    if (String(url).includes('/search/issues?')) {
-      return jsonResponse(200, { items: [] });
-    }
-
     if (String(url) === issueCreateUrl() && init.method === 'POST') {
       const payload = JSON.parse(init.body);
       assert.match(payload.title, /^\[LINE\]\[group\] Support Squad \(Cgroup999\)$/);
@@ -575,6 +625,7 @@ test('group message creates a unique source issue when ISSUE_NUMBER is omitted',
 
   try {
     const ctx = createContext();
+    const mockDB = createMockD1();
     const { env, request } = await createSignedRequest(
       '/line/webhook',
       {
@@ -598,6 +649,7 @@ test('group message creates a unique source issue when ISSUE_NUMBER is omitted',
       },
       {
         ISSUE_NUMBER: undefined,
+        DB: mockDB,
       },
     );
 

--- a/workers/line-bot/test/worker.test.js
+++ b/workers/line-bot/test/worker.test.js
@@ -616,11 +616,7 @@ test('group message creates a unique source issue when ISSUE_NUMBER is omitted',
     }
 
     if (
-      [
-        repoLabelUrl('linebotworker'),
-        repoLabelUrl('line'),
-        repoLabelUrl('line:group'),
-      ].includes(String(url)) &&
+      [repoLabelUrl('linebotworker')].includes(String(url)) &&
       init.method === 'GET'
     ) {
       return notFoundResponse();
@@ -638,7 +634,7 @@ test('group message creates a unique source issue when ISSUE_NUMBER is omitted',
       assert.match(payload.body, /- Source key: group:Cgroup999/);
       assert.match(payload.body, /- Group ID: Cgroup999/);
       assert.match(payload.body, /- Source display name: Support Squad/);
-      assert.deepEqual(payload.labels, ['linebotworker', 'line', 'line:group']);
+      assert.deepEqual(payload.labels, ['linebotworker']);
 
       return jsonResponse(201, {
         number: dynamicIssueNumber,

--- a/workers/line-bot/wrangler.jsonc
+++ b/workers/line-bot/wrangler.jsonc
@@ -12,5 +12,12 @@
     "LINE_DATA_API_BASE_URL": "https://api-data.line.me",
     "LINE_WEBHOOK_PATH": "/line/webhook",
     "GITHUB_API_VERSION": "2022-11-28"
-  }
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "line-bot-db",
+      "database_id": "PLACEHOLDER"
+    }
+  ]
 }


### PR DESCRIPTION
﻿讓 LINE Bot Worker 更穩定，支援動態建 issue、群組改名同步、安裝流程自動化。
﻿
﻿﻿1. D1 動態綁定：如果你沒有指定固定的小龍蝦編號，Worker 會依照 LINE 的來源（個人 / 群組 / 聊天室）自動建立對應的
issue，之後同一來源的訊息都會寫進同一個 issue
 2. 群組改名會自動同步 issue 標題：下次群組有新訊息進來時，Worker 會去抓最新的群組名稱，如果跟 issue 標題不一樣就自動更新
 3. issue 被刪掉會自動重建：如果綁定的 issue 被人刪了，下次收到訊息時會自動建一個新的
 4. LINE reply 失敗不會影響訊息記錄：以前如果 LINE 回覆失敗，整個流程會中斷；現在回覆失敗只會 log 警告，訊息還是會正常寫進 GitHub
 5. 安裝 workflow 修正：修好了 checkout 來源 repo 名稱寫錯、D1 migration 指令缺參數等問題
 6. 安裝時會自動建立 linebotworker label，之後 Worker 新建的 issue 都會掛上這個標籤