### PR TITLE
fix: LINE Bot 媒體路徑修正與 orphan 分支建立

### DIFF
--- a/workers/line-bot/src/domain/line/media.js
+++ b/workers/line-bot/src/domain/line/media.js
@@ -87,6 +87,6 @@ export function isIgnoredEvent(event) {
 export function buildIssueArtifactScope(config, issueNumber) {
   return {
     branch: `issue-${issueNumber}`,
-    directory: `workspaces/issue-${issueNumber}/line`,
+    directory: 'line',
   };
 }

--- a/workers/line-bot/src/infrastructure/github/github-issues-client.js
+++ b/workers/line-bot/src/infrastructure/github/github-issues-client.js
@@ -250,6 +250,32 @@ export async function ensureLabels(config, repo, labels, options = {}) {
   }
 }
 
+async function createOrphanBranch(config, repo, branch) {
+  const repoPath = `/repos/${repo.owner}/${repo.repo}`;
+
+  // 1. 建立空 tree（含 .gitkeep 以避免完全空的 tree）
+  const tree = await githubRequest(config, `${repoPath}/git/trees`, {
+    method: 'POST',
+    body: JSON.stringify({
+      tree: [{ path: '.gitkeep', mode: '100644', type: 'blob', content: '' }],
+    }),
+  });
+
+  // 2. 建立 orphan commit（parents: [] 是關鍵）
+  const commit = await githubRequest(config, `${repoPath}/git/commits`, {
+    method: 'POST',
+    body: JSON.stringify({
+      message: `chore: initialize orphan branch ${branch}`,
+      tree: tree.sha,
+      parents: [],
+    }),
+  });
+
+  // 3. 建立 ref 指向 orphan commit
+  await createRef(config, repo, `heads/${branch}`, commit.sha);
+  return commit.sha;
+}
+
 export async function ensureArtifactBranch(config, repo, branch) {
   const refName = `heads/${branch}`;
   const existing = await getRef(config, repo, refName);
@@ -257,21 +283,7 @@ export async function ensureArtifactBranch(config, repo, branch) {
     return existing.object.sha;
   }
 
-  const repository = await getRepository(config, repo);
-  const defaultBranch = repository?.default_branch;
-  if (typeof defaultBranch !== 'string' || defaultBranch.trim() === '') {
-    throw new Error(
-      'Unable to determine repository default branch for artifact upload.',
-    );
-  }
-
-  const baseRef = await getRef(config, repo, `heads/${defaultBranch}`);
-  if (!baseRef?.object?.sha) {
-    throw new Error(`Unable to resolve base branch SHA for ${defaultBranch}.`);
-  }
-
-  await createRef(config, repo, refName, baseRef.object.sha);
-  return baseRef.object.sha;
+  return createOrphanBranch(config, repo, branch);
 }
 
 export async function findIssueBySourceKey(

--- a/workers/line-bot/test/worker.test.js
+++ b/workers/line-bot/test/worker.test.js
@@ -169,7 +169,7 @@ function issueContentUrl(path, repoFullName = DEFAULT_REPO_FULL_NAME) {
 }
 
 function issueWorkspacePath(fileName, issueNumber = DEFAULT_ISSUE_NUMBER) {
-  return `workspaces/issue-${issueNumber}/line/${fileName}`;
+  return `line/${fileName}`;
 }
 
 function repoLabelUrl(name, repoFullName = DEFAULT_REPO_FULL_NAME) {
@@ -221,7 +221,7 @@ function createArtifactUploadResponder({
   path,
   commitMessage,
   putResponsePath = path,
-  baseSha = `main-sha-${issueNumber}`,
+  baseSha = `orphan-sha-${issueNumber}`,
 }) {
   return (url, init = {}) => {
     const requestUrl = String(url);
@@ -230,18 +230,25 @@ function createArtifactUploadResponder({
       return notFoundResponse();
     }
 
-    if (requestUrl === repositoryUrl(repoFullName)) {
-      return jsonResponse(200, { default_branch: 'main' });
+    // orphan branch creation: createTree
+    if (
+      requestUrl === `${repositoryUrl(repoFullName)}/git/trees` &&
+      init.method === 'POST'
+    ) {
+      return jsonResponse(201, { sha: `tree-sha-${issueNumber}` });
     }
 
-    if (requestUrl === defaultBranchRefUrl(repoFullName)) {
-      return jsonResponse(200, {
-        object: {
-          sha: baseSha,
-        },
-      });
+    // orphan branch creation: createCommit (parents: [])
+    if (
+      requestUrl === `${repositoryUrl(repoFullName)}/git/commits` &&
+      init.method === 'POST'
+    ) {
+      const payload = JSON.parse(init.body);
+      assert.deepStrictEqual(payload.parents, []);
+      return jsonResponse(201, { sha: baseSha });
     }
 
+    // orphan branch creation: createRef
     if (
       requestUrl === `${repositoryUrl(repoFullName)}/git/refs` &&
       init.method === 'POST'
@@ -919,15 +926,15 @@ test('image message uploads media to the fixed issue branch and comments with pr
     assert.match(commentPayload.body, /- Issue branch: `issue-501`/);
     assert.match(
       commentPayload.body,
-      /- Repo path: `workspaces\/issue-501\/line\/image-55\.png`/,
+      /- Repo path: `line\/image-55\.png`/,
     );
     assert.match(
       commentPayload.body,
-      /blob\/issue-501\/workspaces\/issue-501\/line\/image-55\.png\?raw=true/,
+      /blob\/issue-501\/line\/image-55\.png\?raw=true/,
     );
     assert.match(
       commentPayload.body,
-      /!\[image-55\.png\]\(https:\/\/github\.com\/octo\/fallback\/blob\/issue-501\/workspaces\/issue-501\/line\/image-55\.png\?raw=true\)/,
+      /!\[image-55\.png\]\(https:\/\/github\.com\/octo\/fallback\/blob\/issue-501\/line\/image-55\.png\?raw=true\)/,
     );
 
     const uploadCall = fetchStub.calls.find(
@@ -1012,7 +1019,7 @@ test('audio, video, and file uploads use the fixed issue branch and comment on t
       assert.match(commentPayload.body, /Issue branch: `issue-501`/);
       assert.match(
         commentPayload.body,
-        /Repo path: `workspaces\/issue-501\/line\/audio-1\.mp3`/,
+        /Repo path: `line\/audio-1\.mp3`/,
       );
     } finally {
       fetchStub.restore();
@@ -1088,11 +1095,11 @@ test('audio, video, and file uploads use the fixed issue branch and comment on t
       assert.match(commentPayload.body, /Issue branch: `issue-501`/);
       assert.match(
         commentPayload.body,
-        /Repo path: `workspaces\/issue-501\/line\/video-1\.mp4`/,
+        /Repo path: `line\/video-1\.mp4`/,
       );
       assert.match(
         commentPayload.body,
-        /<video src="https:\/\/github\.com\/octo\/fallback\/blob\/issue-501\/workspaces\/issue-501\/line\/video-1\.mp4\?raw=true"/,
+        /<video src="https:\/\/github\.com\/octo\/fallback\/blob\/issue-501\/line\/video-1\.mp4\?raw=true"/,
       );
     } finally {
       fetchStub.restore();
@@ -1164,7 +1171,7 @@ test('audio, video, and file uploads use the fixed issue branch and comment on t
       assert.match(commentPayload.body, /Issue branch: `issue-501`/);
       assert.match(
         commentPayload.body,
-        /Repo path: `workspaces\/issue-501\/line\/file-1\.txt`/,
+        /Repo path: `line\/file-1\.txt`/,
       );
     } finally {
       textFetchStub.restore();
@@ -1238,7 +1245,7 @@ test('audio, video, and file uploads use the fixed issue branch and comment on t
       assert.match(commentPayload.body, /Stored file: \[meeting-notes\.docx\]/);
       assert.match(
         commentPayload.body,
-        /Repo path: `workspaces\/issue-501\/line\/word-1\.docx`/,
+        /Repo path: `line\/word-1\.docx`/,
       );
       assert.match(commentPayload.body, /Issue branch: `issue-501`/);
     } finally {
@@ -1396,16 +1403,20 @@ test('image upload permission error becomes a readable comment on the fixed issu
       return notFoundResponse();
     }
 
-    if (String(url) === repositoryUrl()) {
-      return jsonResponse(200, { default_branch: 'main' });
+    // orphan branch creation: createTree
+    if (
+      String(url) === `${repositoryUrl()}/git/trees` &&
+      init.method === 'POST'
+    ) {
+      return jsonResponse(201, { sha: 'tree-sha-orphan' });
     }
 
-    if (String(url) === defaultBranchRefUrl()) {
-      return jsonResponse(200, {
-        object: {
-          sha: 'main-sha-99',
-        },
-      });
+    // orphan branch creation: createCommit (parents: [])
+    if (
+      String(url) === `${repositoryUrl()}/git/commits` &&
+      init.method === 'POST'
+    ) {
+      return jsonResponse(201, { sha: 'orphan-sha-99' });
     }
 
     if (
@@ -1415,7 +1426,7 @@ test('image upload permission error becomes a readable comment on the fixed issu
       return jsonResponse(201, {
         ref: 'refs/heads/issue-501',
         object: {
-          sha: 'main-sha-99',
+          sha: 'orphan-sha-99',
         },
       });
     }


### PR DESCRIPTION
## 變更說明

### 1. 媒體上傳路徑修正
- 將 LINE Bot 媒體檔案上傳路徑從 `workspaces/issue-N/line` 改為 `line/`
- 簡化路徑結構，與 AGENTS.md 的說明一致

### 2. 改用 Orphan 分支建立 Issue Branch
- `ensureArtifactBranch` 原本從 main 分支 fork，導致新分支繼承了 `.github/workflows`、`templates` 等不需要的檔案
- 改為建立 orphan 分支（透過 Git Data API：createTree → createCommit with `parents: []` → createRef）
- 新的 issue branch 只會有 `.gitkeep`，不再包含 main 的檔案

### 測試
- 32 個測試全部通過
- 測試 mock 已同步更新為 orphan 分支建立流程