### PR TITLE
fix: post-process AI-generated GitHub URLs and branch metadata in update-comment-action

### DIFF
--- a/actions/update-comment-action/action.yml
+++ b/actions/update-comment-action/action.yml
@@ -38,6 +38,15 @@ runs:
         # 1. 有存在的 message_file：讀取檔案內容
         # 2. 其他情況：改用執行失敗 fallback 訊息
         if [[ -n "${MESSAGE_FILE}" && -f "${MESSAGE_FILE}" ]]; then
+          # 自動攔截並修正 AI 可能產生錯誤的 artifacts 網址與分支名稱 (Post-processing)
+          BRANCH_NAME="issue-${ISSUE_NUMBER}"
+          
+          # 修正 1: Markdown 圖片/連結的 GitHub URL (替換 owner, repo, branch)
+          sed -i -E "s|https://github.com/[^/]+/[^/]+/blob/[^/]+/artifacts/|https://github.com/${REPOSITORY}/blob/${BRANCH_NAME}/artifacts/|g" "${MESSAGE_FILE}"
+          
+          # 修正 2: HTML 註解內 JSON metadata 的 branch 屬性
+          sed -i -E "s|\"branch\":\"[^\"]+\"|\"branch\":\"${BRANCH_NAME}\"|g" "${MESSAGE_FILE}"
+          
           message="$(cat "${MESSAGE_FILE}")"
         else
           message="$(printf '❌ 執行失敗。請查看 Workflow 執行記錄。')"


### PR DESCRIPTION
在 actions/update-comment-action/action.yml 中加入簡單的 post-processing（使用 sed）來修正 AI 產生的 GitHub artifacts URL 與 HTML 註解中的 JSON metadata 的 branch 欄位，避免錯誤的 owner/repo/branch（例如出現 owner/owner 的錯誤連結在 issue comment）被原樣寫入 issue comment。