### PR TITLE
fix(copilot-byok): 修正 NIM GLM 模型 ID 拼寫

### DIFF
--- a/templates/copilot-byok/githubclaw.json
+++ b/templates/copilot-byok/githubclaw.json
@@ -31,8 +31,8 @@
         { "value": "nvidia/nemotron-3-super-120b-a12b", "label": "Nemotron 3 Super 120B" },
         { "value": "openai/gpt-oss-120b", "label": "GPT OSS 120B" },
         { "value": "minimaxai/minimax-m2.7", "label": "MiniMax M2.7" },
-        { "value": "z-ai/glm5.1", "label": "GLM 5.1" },
-        { "value": "z-ai/glm4.7", "label": "GLM 4.7" },
+        { "value": "z-ai/glm-5.1", "label": "GLM 5.1" },
+        { "value": "z-ai/glm-4.7", "label": "GLM 4.7" },
         { "value": "mistralai/mistral-medium-3.5-128b", "label": "Mistral Medium 3.5 128B" },
         { "value": "deepseek-ai/deepseek-v4-flash", "label": "DeepSeek V4 Flash" },
         { "value": "deepseek-ai/deepseek-v4-pro", "label": "DeepSeek V4 Pro" }


### PR DESCRIPTION
## 概述
修正 `copilot-byok` 範本中 NIM provider 的 GLM 模型 ID 拼寫錯誤（少了連字號），避免 NIM 回 404。

## 問題描述
`templates/copilot-byok/githubclaw.json` 中兩個 GLM 模型 ID 寫成 `z-ai/glm5.1` / `z-ai/glm4.7`，但 NIM 實際 ID 為 `z-ai/glm-5.1` / `z-ai/glm-4.7`，使用者選到時會收到：

```
Model 'z-ai/glm-4.7' not found on provider at https://integrate.api.nvidia.com/v1 (HTTP 404).
```

## 變更內容
- `z-ai/glm5.1` → `z-ai/glm-5.1`
- `z-ai/glm4.7` → `z-ai/glm-4.7`

## 測試方式
- 在 NIM 重新跑提示詞，確認模型回應正常
