### PR TITLE
feat(pi-byok): 新增 Groq provider 支援

### DIFF
--- a/templates/pi-byok/.github/workflows/issue-N.yml
+++ b/templates/pi-byok/.github/workflows/issue-N.yml
@@ -106,8 +106,10 @@ jobs:
         run: |
           # 讀取 provider（Pi 原生 provider id）
           PROVIDER="cloudflare-workers-ai"
+          MODEL=""
           if [ -f .pi/settings.json ]; then
             PROVIDER=$(jq -r '.defaultProvider // "cloudflare-workers-ai"' .pi/settings.json)
+            MODEL=$(jq -r '.defaultModel // ""' .pi/settings.json)
           fi
 
           # 依 provider 設定對應的 Pi 環境變數
@@ -135,6 +137,13 @@ jobs:
           esac
 
           echo "PI_PROVIDER=$PROVIDER" >> "$GITHUB_ENV"
+          echo "PI_MODEL=$MODEL" >> "$GITHUB_ENV"
+
+          # Groq Compound 目前不接受 reasoning_effort；Pi 預設 thinking=medium 會送出該參數。
+          # 對 Compound 系列自動關閉 thinking，避免 400 reasoning_effort is not supported。
+          if [[ "$PROVIDER" == "groq" && "$MODEL" == groq/compound* ]]; then
+            echo "PI_THINKING_LEVEL=off" >> "$GITHUB_ENV"
+          fi
 
       - name: 執行任務
         if: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.event_data != 'StatusUpdate') || inputs.event_data != 'StatusUpdate' }}
@@ -187,9 +196,15 @@ jobs:
           PI_CODING_AGENT_VERSION='${{ vars.PI_CODING_AGENT_VERSION }}'
           : "${PI_CODING_AGENT_VERSION:=0.70.6}"
 
+          PI_THINKING_ARGS=()
+          if [[ -n "${PI_THINKING_LEVEL:-}" ]]; then
+            PI_THINKING_ARGS=(--thinking "$PI_THINKING_LEVEL")
+          fi
+
           # Pi 會自動讀 .pi/settings.json 的 defaultProvider 與 defaultModel
           # 以 error loglevel 執行，避免 npm warning 汙染 error.log
           npm_config_loglevel=error npx -y "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}" \
+            "${PI_THINKING_ARGS[@]}" \
             -p "請將最終結果寫入 artifacts/${COMMENT_ID}/result.md 。我的提示詞為: ${USER_PROMPT_CONTENT}" \
             --mode json \
             2> "artifacts/${COMMENT_ID}/error.log" \

--- a/templates/pi-byok/.github/workflows/issue-N.yml
+++ b/templates/pi-byok/.github/workflows/issue-N.yml
@@ -101,6 +101,7 @@ jobs:
           SECRET_CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           SECRET_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           SECRET_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SECRET_GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           SECRET_GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           # 讀取 provider（Pi 原生 provider id）
@@ -120,6 +121,9 @@ jobs:
               ;;
             openai)
               echo "OPENAI_API_KEY=${SECRET_OPENAI_API_KEY}" >> "$GITHUB_ENV"
+              ;;
+            groq)
+              echo "GROQ_API_KEY=${SECRET_GROQ_API_KEY}" >> "$GITHUB_ENV"
               ;;
             google)
               echo "GEMINI_API_KEY=${SECRET_GEMINI_API_KEY}" >> "$GITHUB_ENV"

--- a/templates/pi-byok/.github/workflows/issue-N.yml
+++ b/templates/pi-byok/.github/workflows/issue-N.yml
@@ -106,10 +106,8 @@ jobs:
         run: |
           # 讀取 provider（Pi 原生 provider id）
           PROVIDER="cloudflare-workers-ai"
-          MODEL=""
           if [ -f .pi/settings.json ]; then
             PROVIDER=$(jq -r '.defaultProvider // "cloudflare-workers-ai"' .pi/settings.json)
-            MODEL=$(jq -r '.defaultModel // ""' .pi/settings.json)
           fi
 
           # 依 provider 設定對應的 Pi 環境變數
@@ -137,13 +135,6 @@ jobs:
           esac
 
           echo "PI_PROVIDER=$PROVIDER" >> "$GITHUB_ENV"
-          echo "PI_MODEL=$MODEL" >> "$GITHUB_ENV"
-
-          # Groq Compound 目前不接受 reasoning_effort；Pi 預設 thinking=medium 會送出該參數。
-          # 對 Compound 系列自動關閉 thinking，避免 400 reasoning_effort is not supported。
-          if [[ "$PROVIDER" == "groq" && "$MODEL" == groq/compound* ]]; then
-            echo "PI_THINKING_LEVEL=off" >> "$GITHUB_ENV"
-          fi
 
       - name: 執行任務
         if: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.event_data != 'StatusUpdate') || inputs.event_data != 'StatusUpdate' }}
@@ -196,15 +187,9 @@ jobs:
           PI_CODING_AGENT_VERSION='${{ vars.PI_CODING_AGENT_VERSION }}'
           : "${PI_CODING_AGENT_VERSION:=0.70.6}"
 
-          PI_THINKING_ARGS=()
-          if [[ -n "${PI_THINKING_LEVEL:-}" ]]; then
-            PI_THINKING_ARGS=(--thinking "$PI_THINKING_LEVEL")
-          fi
-
           # Pi 會自動讀 .pi/settings.json 的 defaultProvider 與 defaultModel
           # 以 error loglevel 執行，避免 npm warning 汙染 error.log
           npm_config_loglevel=error npx -y "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}" \
-            "${PI_THINKING_ARGS[@]}" \
             -p "請將最終結果寫入 artifacts/${COMMENT_ID}/result.md 。我的提示詞為: ${USER_PROMPT_CONTENT}" \
             --mode json \
             2> "artifacts/${COMMENT_ID}/error.log" \

--- a/templates/pi-byok/githubclaw.json
+++ b/templates/pi-byok/githubclaw.json
@@ -1,10 +1,10 @@
 {
   "name": "Pi BYOK",
-  "tagline": "使用 Pi Coding Agent — 原生支援 Cloudflare、Anthropic、OpenAI、Gemini",
-  "description": "以 Pi Coding Agent 作為小龍蝦執行引擎的範本。每隻小龍蝦可獨立選擇 provider 與 model，API key 按 provider 分開管理。Pi 原生支援多家 provider，不需要額外的轉接層。",
+  "tagline": "使用 Pi Coding Agent — 原生支援 Cloudflare、Anthropic、OpenAI、Gemini、Groq",
+  "description": "以 Pi Coding Agent 作為小龍蝦執行引擎的範本。每隻小龍蝦可獨立選擇 provider 與 model，API key 按 provider 分開管理。Pi 原生支援 Cloudflare、Anthropic、OpenAI、Gemini、Groq 等 provider，不需要額外的轉接層。",
   "category": "ai",
-  "tags": ["pi", "byok", "cloudflare", "anthropic", "openai", "gemini"],
-  "version": "1.0.0",
+  "tags": ["pi", "byok", "cloudflare", "anthropic", "openai", "gemini", "groq"],
+  "version": "1.1.0",
   "support_url": "https://github.com/duotify/GitHubClawToolkit/issues",
   "homepage": "https://learn.duotify.com/courses/githubclaw",
   "byokFlow": true,
@@ -59,6 +59,30 @@
         { "value": "gpt-5.3-codex", "label": "GPT-5.3 Codex" },
         { "value": "gpt-5-mini", "label": "GPT-5 Mini" },
         { "value": "gpt-4.1", "label": "GPT-4.1" }
+      ]
+    },
+    {
+      "id": "groq",
+      "label": "Groq",
+      "description": "使用 Groq 高速推論 API。",
+      "secretName": "GROQ_API_KEY",
+      "defaultModel": "openai/gpt-oss-120b",
+      "models": [
+        { "value": "openai/gpt-oss-120b", "label": "GPT OSS 120B" },
+        { "value": "openai/gpt-oss-20b", "label": "GPT OSS 20B" },
+        { "value": "moonshotai/kimi-k2-instruct", "label": "Kimi K2 Instruct" },
+        { "value": "moonshotai/kimi-k2-instruct-0905", "label": "Kimi K2 Instruct 0905" },
+        { "value": "qwen/qwen3-32b", "label": "Qwen3 32B" },
+        { "value": "qwen-qwq-32b", "label": "Qwen QwQ 32B" },
+        { "value": "deepseek-r1-distill-llama-70b", "label": "DeepSeek R1 Distill Llama 70B" },
+        { "value": "llama-3.3-70b-versatile", "label": "Llama 3.3 70B Versatile" },
+        { "value": "llama-3.1-8b-instant", "label": "Llama 3.1 8B Instant" },
+        { "value": "meta-llama/llama-4-maverick-17b-128e-instruct", "label": "Llama 4 Maverick 17B" },
+        { "value": "meta-llama/llama-4-scout-17b-16e-instruct", "label": "Llama 4 Scout 17B" },
+        { "value": "mistral-saba-24b", "label": "Mistral Saba 24B" },
+        { "value": "gemma2-9b-it", "label": "Gemma 2 9B" },
+        { "value": "groq/compound", "label": "Compound" },
+        { "value": "groq/compound-mini", "label": "Compound Mini" }
       ]
     },
     {

--- a/templates/pi-byok/githubclaw.json
+++ b/templates/pi-byok/githubclaw.json
@@ -80,9 +80,7 @@
         { "value": "meta-llama/llama-4-maverick-17b-128e-instruct", "label": "Llama 4 Maverick 17B" },
         { "value": "meta-llama/llama-4-scout-17b-16e-instruct", "label": "Llama 4 Scout 17B" },
         { "value": "mistral-saba-24b", "label": "Mistral Saba 24B" },
-        { "value": "gemma2-9b-it", "label": "Gemma 2 9B" },
-        { "value": "groq/compound", "label": "Compound" },
-        { "value": "groq/compound-mini", "label": "Compound Mini" }
+        { "value": "gemma2-9b-it", "label": "Gemma 2 9B" }
       ]
     },
     {


### PR DESCRIPTION
## 概述

這個 PR 讓 `pi-byok` template 新增 Groq 作為可選 BYOK provider，使用 Pi Coding Agent 原生支援的 `groq` provider id 與 `GROQ_API_KEY`。既有預設 provider 仍保留 Cloudflare Workers AI，避免影響既有使用者。

## 問題描述

`pi-byok` 目前已支援 Cloudflare Workers AI、Anthropic、OpenAI、Google Gemini，但尚未把 Pi 原生支援的 Groq 暴露在 template provider 清單與 workflow secret mapping 中。使用者即使想用 Groq，也無法透過現有 manifest-driven BYOK 流程直接選擇並在 runtime 注入正確 API key。

## 解決方案

採用既有 `githubclaw.json` 的 manifest-driven provider 架構新增 Groq metadata，並在 `issue-N.yml` 的 provider case mapping 補上 `GROQ_API_KEY`。這樣 `/new` 與切換模型流程可以沿用現有邏輯，不需要額外新增 Core 端 provider flow。

## 變更內容

- [x] 在 `templates/pi-byok/githubclaw.json` 新增 `groq` provider。
- [x] 設定 Groq 的 `secretName` 為 `GROQ_API_KEY`。
- [x] 設定 Groq 預設模型為 `openai/gpt-oss-120b`，並補上靜態模型清單。
- [x] 更新 `pi-byok` tagline、description、tags 與版本。
- [x] 在 `templates/pi-byok/.github/workflows/issue-N.yml` 補上 Groq secret 與環境變數 mapping。
- [x] 移除不支援 tool calling 的 Groq Compound 系列模型選項。

## 測試方式

- 使用 `jq . templates/pi-byok/githubclaw.json` 確認 JSON 合法。
- 驗證 Groq provider 存在，且 `secretName`、`defaultModel`、模型清單與 Cloudflare 預設 provider 設定符合預期。
- 驗證 workflow 包含 `SECRET_GROQ_API_KEY`、`groq)` case，以及 `GROQ_API_KEY=${SECRET_GROQ_API_KEY}` mapping。
- 使用 `git diff --check` 確認沒有 whitespace error。

## 相關連結

- Issue: 無
