### PR TITLE
feat: support BYOK in line-bot and dynamic pioneer provider extension in pi-byok

### DIFF
--- a/templates/line-bot/.github/workflows/issue-N.yml
+++ b/templates/line-bot/.github/workflows/issue-N.yml
@@ -123,6 +123,41 @@ jobs:
             echo "::warning::build-chat-log.js 不存在，略過聊天記錄整理步驟"
           fi
 
+      # BYOK：從分支 .copilot/config.json 讀取 per-lobster 覆寫設定，並根據 provider 選取對應的 API key
+      - name: 讀取 BYOK 設定
+        if: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.event_data != 'StatusUpdate') || inputs.event_data != 'StatusUpdate' }}
+        shell: bash
+        env:
+          BYOK_KEY_NVIDIA_NIM: ${{ secrets.COPILOT_BYOK_NIM_KEY }}
+          BYOK_KEY_GROQ: ${{ secrets.COPILOT_BYOK_GROQ_KEY }}
+          BYOK_KEY_CLOUDFLARE: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          BYOK_KEY_CUSTOM: ${{ secrets.COPILOT_PROVIDER_API_KEY }}
+          BYOK_KEY_PIONEER: ${{ secrets.PIONEER_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -f .copilot/config.json ]; then
+            OVR_URL=$(jq -r '.providerBaseUrl // empty' .copilot/config.json)
+            OVR_MODEL=$(jq -r '.byokModel // empty' .copilot/config.json)
+            OVR_TYPE=$(jq -r '.providerType // empty' .copilot/config.json)
+            PROVIDER=$(jq -r '.provider // "custom"' .copilot/config.json)
+
+            # CloudFlare：若 config.json 沒有 providerBaseUrl，自動從 secret 組合
+            if [ "$PROVIDER" = "cloudflare" ] && [ -z "$OVR_URL" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
+              OVR_URL="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1"
+            fi
+
+            if [ -n "$OVR_URL" ];   then echo "COPILOT_PROVIDER_BASE_URL=$OVR_URL" >> "$GITHUB_ENV"; fi
+            if [ -n "$OVR_MODEL" ]; then echo "COPILOT_MODEL=$OVR_MODEL" >> "$GITHUB_ENV"; fi
+            if [ -n "$OVR_TYPE" ];  then echo "COPILOT_PROVIDER_TYPE=$OVR_TYPE" >> "$GITHUB_ENV"; fi
+
+            # 根據 provider 選取對應的 API key
+            KEY_VAR="BYOK_KEY_$(echo "$PROVIDER" | tr '[:lower:]-' '[:upper:]_')"
+            API_KEY="${!KEY_VAR}"
+            if [ -n "$API_KEY" ]; then
+              echo "COPILOT_PROVIDER_API_KEY=$API_KEY" >> "$GITHUB_ENV"
+            fi
+          fi
+
       - name: 執行任務
         if: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.event_data != 'StatusUpdate') || inputs.event_data != 'StatusUpdate' }}
         id: copilot_task
@@ -130,6 +165,10 @@ jobs:
         env:
           COPILOT_GITHUB_TOKEN: ${{ env.COPILOT_GITHUB_TOKEN }}
           COPILOT_HOME: ".copilot"
+          COPILOT_PROVIDER_API_KEY: ${{ env.COPILOT_PROVIDER_API_KEY }}
+          COPILOT_PROVIDER_BASE_URL: ${{ env.COPILOT_PROVIDER_BASE_URL }}
+          COPILOT_MODEL: ${{ env.COPILOT_MODEL }}
+          COPILOT_PROVIDER_TYPE: ${{ env.COPILOT_PROVIDER_TYPE || 'openai' }}
         run: |
           RAW_ISSUE_NUMBER='${{ env.ISSUE_NUMBER }}'
           RAW_COMMENT_ID='${{ env.COMMENT_ID }}'
@@ -178,14 +217,27 @@ jobs:
             --yolo --stream off --output-format json \
             > "artifacts/${COMMENT_ID}/output.jsonl" \
             2> "artifacts/${COMMENT_ID}/error.log"
-          EXIT_CODE=$?
+          COPILOT_EXIT=$?
           set -e
 
+          # Copilot CLI 的錯誤事件（session.error / model.call_failure）會輸出到 stdout 的 jsonl，
+          # 不會進 stderr，導致 error.log 為空。這裡從 output.jsonl 抽出錯誤訊息補進 error.log。
+          if [ -f "artifacts/${COMMENT_ID}/output.jsonl" ]; then
+            jq -r '
+              if .type == "session.error" then (.data.message // empty)
+              elif .type == "model.call_failure" then (.data.errorMessage // empty)
+              else empty
+              end
+            ' "artifacts/${COMMENT_ID}/output.jsonl" 2>/dev/null \
+              | awk 'NF && !seen[$0]++' \
+              >> "artifacts/${COMMENT_ID}/error.log" || true
+          fi
+
           if [[ -s "artifacts/${COMMENT_ID}/result.md" ]]; then
-            echo "Warning: Copilot CLI exited with code ${EXIT_CODE}, but result.md was generated."
+            echo "Warning: Copilot CLI exited with code ${COPILOT_EXIT}, but result.md was generated."
             exit 0
           else
-            exit ${EXIT_CODE}
+            exit ${COPILOT_EXIT}
           fi
 
       - name: 推送結果

--- a/templates/line-bot/githubclaw.json
+++ b/templates/line-bot/githubclaw.json
@@ -7,5 +7,95 @@
   "version": "1.0.0",
   "support_url": "https://github.com/duotify/GitHubClawToolkit/issues",
   "homepage": "https://learn.duotify.com/courses/githubclaw",
-  "requireEnv": ["LINE_CHANNEL_ACCESS_TOKEN", "LINE_CHANNEL_SECRET"]
+  "requireEnv": ["LINE_CHANNEL_ACCESS_TOKEN", "LINE_CHANNEL_SECRET"],
+  "byokFlow": true,
+  "byokConfig": {
+    "path": ".copilot/config.json",
+    "providerField": "provider",
+    "modelField": "byokModel",
+    "providerBaseUrlField": "providerBaseUrl",
+    "providerTypeField": "providerType",
+    "merge": false
+  },
+  "providers": [
+    {
+      "id": "nvidia-nim",
+      "label": "NVIDIA NIM",
+      "description": "使用 NVIDIA Integrate API 作為 Copilot BYOK provider。",
+      "secretName": "COPILOT_BYOK_NIM_KEY",
+      "presetVariables": {
+        "providerBaseUrl": "https://integrate.api.nvidia.com/v1",
+        "providerType": "openai"
+      },
+      "defaultModel": "nvidia/nemotron-3-super-120b-a12b",
+      "models": [
+        { "value": "nvidia/nemotron-3-super-120b-a12b", "label": "Nemotron 3 Super 120B" },
+        { "value": "openai/gpt-oss-120b", "label": "GPT OSS 120B" },
+        { "value": "minimaxai/minimax-m2.7", "label": "MiniMax M2.7" },
+        { "value": "z-ai/glm-5.1", "label": "GLM 5.1" },
+        { "value": "z-ai/glm-4.7", "label": "GLM 4.7" },
+        { "value": "mistralai/mistral-medium-3.5-128b", "label": "Mistral Medium 3.5 128B" },
+        { "value": "deepseek-ai/deepseek-v4-flash", "label": "DeepSeek V4 Flash" },
+        { "value": "deepseek-ai/deepseek-v4-pro", "label": "DeepSeek V4 Pro" }
+      ]
+    },
+    {
+      "id": "cloudflare",
+      "label": "Cloudflare",
+      "description": "使用 Cloudflare Workers AI 推論 API。",
+      "isDefault": true,
+      "secretName": "CLOUDFLARE_API_TOKEN",
+      "presetVariables": {
+        "providerType": "openai"
+      },
+      "defaultModel": "@cf/google/gemma-4-26b-a4b-it",
+      "models": [
+        { "value": "@cf/moonshotai/kimi-k2.6", "label": "Kimi K2.6" },
+        { "value": "@cf/zai-org/glm-4.7-flash", "label": "GLM 4.7 Flash" },
+        { "value": "@cf/openai/gpt-oss-120b", "label": "GPT OSS 120B" },
+        { "value": "@cf/meta/llama-4-scout-17b-16e-instruct", "label": "Llama 4 Scout 17B" },
+        { "value": "@cf/google/gemma-4-26b-a4b-it", "label": "Gemma4b" },
+        { "value": "@cf/nvidia/nemotron-3-120b-a12b", "label": "Nemotron 3 120B" }
+      ]
+    },
+    {
+      "id": "pioneer",
+      "label": "Pioneer",
+      "description": "透過 Pioneer OpenAI-compatible endpoint 使用多種模型，需設定 PIONEER_API_KEY。",
+      "secretName": "PIONEER_API_KEY",
+      "presetVariables": {
+        "providerBaseUrl": "https://api.pioneer.ai/v1",
+        "providerType": "openai"
+      },
+      "defaultModel": "gpt-5.5",
+      "models": [
+        { "value": "gpt-5.5", "label": "Pioneer GPT-5.5" },
+        { "value": "claude-sonnet-4-6", "label": "Pioneer Claude Sonnet 4.6" },
+        { "value": "claude-opus-4-7", "label": "Pioneer Claude Opus 4.7" },
+        { "value": "deepseek-ai/DeepSeek-V4-Pro", "label": "Pioneer DeepSeek V4 Pro" },
+        { "value": "moonshotai/Kimi-K2.6", "label": "Pioneer Kimi K2.6" }
+      ]
+    },
+    {
+      "id": "custom",
+      "label": "自行設定",
+      "description": "手動輸入自訂 BYOK provider 的 endpoint、provider type 與 model。",
+      "secretName": "COPILOT_PROVIDER_API_KEY",
+      "variableInputs": [
+        {
+          "name": "providerBaseUrl",
+          "label": "Provider Base URL"
+        },
+        {
+          "name": "providerType",
+          "label": "Provider Type",
+          "default": "openai"
+        },
+        {
+          "name": "byokModel",
+          "label": "Model"
+        }
+      ]
+    }
+  ]
 }

--- a/templates/pi-byok/.github/workflows/issue-N.yml
+++ b/templates/pi-byok/.github/workflows/issue-N.yml
@@ -197,6 +197,12 @@ jobs:
           PI_CODING_AGENT_VERSION='${{ vars.PI_CODING_AGENT_VERSION }}'
           : "${PI_CODING_AGENT_VERSION:=0.70.6}"
 
+          # 若選取 pioneer，則需要先安裝 pi-pioneer-provider 延伸模組
+          if [[ "${PI_PROVIDER}" == "pioneer" ]]; then
+            echo "Installing pi-pioneer-provider extension..."
+            npx -y "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}" install npm:pi-pioneer-provider
+          fi
+
           # Pi 會透過 PI_CODING_AGENT_DIR=.pi 讀取 template 內的 settings.json 與 models.json
           # 以 error loglevel 執行，避免 npm warning 汙染 error.log
           set +e


### PR DESCRIPTION

本 PR 解決了小龍蝦在 `GitHub Copilot` 訂閱過期後導致的執行中斷，並完善了對 `Pioneer` 的整合。解耦了 `line-bot` 範本對官方 Copilot API 的強依賴，新增 BYOK 機制。

1. **`line-bot` 範本解耦與 BYOK 整合**
   * **問題**：先前 `line-bot` 強綁定 Copilot CLI，一旦 `COPILOT_GITHUB_TOKEN` 失效即無法運行。
   * **解法**：在 `githubclaw.json` 中配置 `byokConfig` 與 `providers` 列表。工作流程中引入 `讀取 BYOK 設定` 步驟，利用 **Bash 的間接變數引用 (`${!KEY_VAR}`)**，動態將對應的 Secret（如 `PIONEER_API_KEY`）動態映射至 `COPILOT_PROVIDER_API_KEY`。此設計可確保未來新增 Provider 時，**完全不需要修改 YAML 工作流程**。
   * **向下相容性**：若無 BYOK 設定，流程會自動安全 Fallback 回預設的 Copilot 認證機制，不影響現有使用者。

2. **Pioneer 延伸模組動態按需載入 (On-Demand Extension Provisioning)**
   * **問題**：`pi-byok` 範本調用 `pi-coding-agent` 時，若使用 `pioneer` 需額外的 `pi-pioneer-provider` 外掛。
   * **解法**：在 Actions 中加入條件判斷，僅在 `PI_PROVIDER == 'pioneer'` 時才執行 `npx ... install npm:pi-pioneer-provider`。

---

####  測試結果
* **`line-bot` 範本驗證**（參考附圖 1）：切換為 `pioneer / claude-opus-4-7` 後，小龍蝦能正確透過自建 endpoint 進行推論，且沒有任何 Copilot 授權出錯。
<img width="530" height="507" alt="截圖 2026-06-11 下午2 40 25" src="https://github.com/user-attachments/assets/5ef1d863-1919-4bb5-8087-28bc1ae51da9" />
* **`pi-byok` 範本驗證**（參考附圖 2）：切換為 `pioneer` 後，Actions Runner 順利動態安裝 provider 並成功生成推論回覆。
<img width="528" height="560" alt="截圖 2026-06-11 下午2 40 11" src="https://github.com/user-attachments/assets/277ab851-3566-41ad-a6ef-e374e75260ec" />
