### PR TITLE
docs(antigravity-gcp): 補充 Windows 使用者取得 AGY_OAUTH_TOKEN 的說明

### DIFF
--- a/templates/antigravity-gcp/README.md
+++ b/templates/antigravity-gcp/README.md
@@ -9,7 +9,7 @@
 - Google Cloud 帳號（已啟用免費試用 $300 額度）
 - 本機已安裝 Antigravity CLI（`agy`）
 
-### 步驟
+### 步驟（Linux / macOS / WSL）
 
 1. 在終端機執行：
 
@@ -33,7 +33,23 @@ agy --print "hello"
 cat ~/.gemini/antigravity-cli/antigravity-oauth-token
 ```
 
-輸出會是一段 JSON，類似：
+### 步驟（Windows）
+
+Windows 版 `agy` 會把 OAuth 憑證存在系統的 Credential Manager（`gemini:antigravity`），不會產生 `antigravity-oauth-token` 檔案。請先完成登入，再用 PowerShell 匯出 JSON。
+
+1. 在 PowerShell 執行 `agy`，完成 Google 授權。
+
+> ⚠️ **重要：請選擇「Use a Google Cloud Project」**，不要登入個人的 Google AI Pro 帳號。選擇你建立好的 GCP 專案來授權。
+
+2. 在 PowerShell 貼上以下指令（一次貼上整行），輸出即為 `AGY_OAUTH_TOKEN` 所需的 JSON：
+
+```powershell
+if(-not('AgyCred'-as[type])){Add-Type 'using System;using System.Runtime.InteropServices;using System.Text;public class AgyCred{[StructLayout(LayoutKind.Sequential,CharSet=CharSet.Unicode)]public struct R{public int F,T;public string N,C;public System.Runtime.InteropServices.ComTypes.FILETIME L;public int S;public IntPtr B,P,A;public string X,U;}[DllImport("advapi32.dll",CharSet=CharSet.Unicode)]public static extern bool CredRead(string t,int y,int z,out IntPtr p);[DllImport("advapi32.dll")]public static extern bool CredFree(IntPtr p);}'};$p=[IntPtr]::Zero;try{if(-not[AgyCred]::CredRead('gemini:antigravity',1,0,[ref]$p)){throw 'agy credential not found'};$r=[Runtime.InteropServices.Marshal]::PtrToStructure($p,[type][AgyCred+R]);$b=New-Object byte[] $r.S;[Runtime.InteropServices.Marshal]::Copy($r.B,$b,0,$r.S);[Text.Encoding]::UTF8.GetString($b).Trim([char]0)}finally{if($p-ne[IntPtr]::Zero){[AgyCred]::CredFree($p)|Out-Null}}
+```
+
+### 複製 JSON 到 GitHub Secret
+
+不論使用哪個平台，輸出都會是一段 JSON，類似：
 
 ```json
 {
@@ -47,7 +63,7 @@ cat ~/.gemini/antigravity-cli/antigravity-oauth-token
 }
 ```
 
-5. 複製**整份 JSON 內容**，這就是 `AGY_OAUTH_TOKEN` 的值。
+複製**整份 JSON 內容**，這就是 `AGY_OAUTH_TOKEN` 的值。
 
 > ⚠️ 請複製完整的 JSON，不是只有 refresh_token 欄位。
 


### PR DESCRIPTION
## 概述

補充 Antigravity GCP 範本 README，讓未安裝 WSL 的 Windows 使用者也能取得 `AGY_OAUTH_TOKEN` 所需的 JSON。

## 問題描述

Windows 版 `agy` 登入後會將 OAuth 憑證存入 Credential Manager（`gemini:antigravity`），不會產生 `~/.gemini/antigravity-cli/antigravity-oauth-token` 檔案。學員依照原本文件操作時，容易誤以為登入失敗或找不到 token。

## 解決方案

- 將原有流程明確標示為 Linux / macOS / WSL 適用
- 新增 Windows 專用步驟：先以 `agy` 完成 GCP 授權，再以 PowerShell 單行指令從 Credential Manager 匯出 JSON
- 將「複製 JSON 到 GitHub Secret」整理為跨平台共用章節

## 變更內容

- [x] 更新 `templates/antigravity-gcp/README.md` 的 AGY_OAUTH_TOKEN 取得說明
- [x] 新增 Windows PowerShell 匯出指令（含 try/finally 與重複執行防護）

## 測試方式

- 在 Windows PowerShell 完成 `agy` GCP 登入後，貼上 README 中的單行指令
- 確認輸出為完整 JSON，且包含 `token.refresh_token`
- 將 JSON 貼入 GitHub Secret `AGY_OAUTH_TOKEN` 後，觸發小龍蝦 workflow 驗證登入成功

## 相關連結

- 變更檔案：`templates/antigravity-gcp/README.md`