### PR TITLE
feat(templates): Copilot 範本改用 GITHUB_TOKEN 驗證

### DIFF
--- a/templates/copilot-byok/.github/workflows/issue-N.yml
+++ b/templates/copilot-byok/.github/workflows/issue-N.yml
@@ -181,7 +181,6 @@ jobs:
           USER_PROMPT_CONTENT="$(cat "$USER_PROMPT_FILE")"
 
           set +e
-          set +e
           npx -y @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.68' }} \
             -p "請將最終結果寫入 artifacts/${COMMENT_ID}/result.md 。我的提示詞為: ${USER_PROMPT_CONTENT}" \
             --yolo --stream off --output-format json \

--- a/templates/copilot-byok/.github/workflows/issue-N.yml
+++ b/templates/copilot-byok/.github/workflows/issue-N.yml
@@ -54,6 +54,7 @@ concurrency:
 permissions:
   contents: write
   issues: write
+  copilot-requests: write
 
 # 把不同 trigger 的 payload 統一整理成共用環境變數，後續 step 只要讀 env 即可。
 env:
@@ -63,8 +64,6 @@ env:
   COMMENT_ID: "${{ github.event_name == 'repository_dispatch' && github.event.client_payload.comment_id || inputs.comment_id }}"
   # 這次觸發來源的使用者留言 id，用來讀取對應的 user.md。
   USER_COMMENT_ID: "${{ github.event_name == 'repository_dispatch' && github.event.client_payload.user_comment_id || inputs.user_comment_id }}"
-  # 給 Copilot CLI 做 GitHub 驗證用的 token；實際權限要看 repo secrets 如何配置。
-  COPILOT_GITHUB_TOKEN: "${{ secrets.COPILOT_GITHUB_TOKEN }}"
 
 jobs:
   # 單一主 job：在 GitHub-hosted runner 上完成驗證、執行 agent、寫回結果。
@@ -133,7 +132,7 @@ jobs:
         id: copilot_task
         shell: bash
         env:
-          COPILOT_GITHUB_TOKEN: ${{ env.COPILOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           COPILOT_HOME: ".copilot"
           COPILOT_PROVIDER_API_KEY: ${{ env.COPILOT_PROVIDER_API_KEY }}
           COPILOT_PROVIDER_BASE_URL: ${{ env.COPILOT_PROVIDER_BASE_URL }}
@@ -183,7 +182,7 @@ jobs:
 
           set +e
           set +e
-          npx -y @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.27' }} \
+          npx -y @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.68' }} \
             -p "請將最終結果寫入 artifacts/${COMMENT_ID}/result.md 。我的提示詞為: ${USER_PROMPT_CONTENT}" \
             --yolo --stream off --output-format json \
             > "artifacts/${COMMENT_ID}/output.jsonl" \

--- a/templates/copilot-default/.github/workflows/issue-N.yml
+++ b/templates/copilot-default/.github/workflows/issue-N.yml
@@ -54,6 +54,7 @@ concurrency:
 permissions:
   contents: write
   issues: write
+  copilot-requests: write
 
 # 把不同 trigger 的 payload 統一整理成共用環境變數，後續 step 只要讀 env 即可。
 env:
@@ -63,8 +64,6 @@ env:
   COMMENT_ID: "${{ github.event_name == 'repository_dispatch' && github.event.client_payload.comment_id || inputs.comment_id }}"
   # 這次觸發來源的使用者留言 id，用來讀取對應的 user.md。
   USER_COMMENT_ID: "${{ github.event_name == 'repository_dispatch' && github.event.client_payload.user_comment_id || inputs.user_comment_id }}"
-  # 給 Copilot CLI 做 GitHub 驗證用的 token；實際權限要看 repo secrets 如何配置。
-  COPILOT_GITHUB_TOKEN: "${{ secrets.COPILOT_GITHUB_TOKEN }}"
 
 jobs:
   # 單一主 job：在 GitHub-hosted runner 上完成驗證、執行 agent、寫回結果。
@@ -99,7 +98,7 @@ jobs:
         id: copilot_task
         shell: bash
         env:
-          COPILOT_GITHUB_TOKEN: ${{ env.COPILOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           COPILOT_HOME: ".copilot"
         run: |
           RAW_ISSUE_NUMBER='${{ env.ISSUE_NUMBER }}'
@@ -144,7 +143,7 @@ jobs:
           USER_PROMPT_CONTENT="$(cat "$USER_PROMPT_FILE")"
 
           set +e
-          npx -y @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.27' }} \
+          npx -y @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.68' }} \
             -p "請將最終結果寫入 artifacts/${COMMENT_ID}/result.md 。我的提示詞為: ${USER_PROMPT_CONTENT}" \
             --yolo --stream off --output-format json \
             > "artifacts/${COMMENT_ID}/output.jsonl" \

--- a/templates/copilot-felo/.github/workflows/issue-N.yml
+++ b/templates/copilot-felo/.github/workflows/issue-N.yml
@@ -54,6 +54,7 @@ concurrency:
 permissions:
   contents: write
   issues: write
+  copilot-requests: write
 
 # 把不同 trigger 的 payload 統一整理成共用環境變數，後續 step 只要讀 env 即可。
 env:
@@ -62,8 +63,6 @@ env:
   # 若有提供現成的 comment id，就直接更新那則留言。
   COMMENT_ID: "${{ github.event_name == 'repository_dispatch' && github.event.client_payload.comment_id || inputs.comment_id }}"
   USER_COMMENT_ID: "${{ github.event_name == 'repository_dispatch' && github.event.client_payload.user_comment_id || inputs.user_comment_id }}"
-  # 給 Copilot CLI 做 GitHub 驗證用的 token；實際權限要看 repo secrets 如何配置。
-  COPILOT_GITHUB_TOKEN: "${{ secrets.COPILOT_GITHUB_TOKEN }}"
   # 給 Copilot CLI 做 FELO API 認證用的金鑰；實際權限要看 repo secrets 如何配置。
   FELO_API_KEY: "${{ secrets.FELO_API_KEY }}"
 
@@ -91,7 +90,7 @@ jobs:
 
       # 安裝 GitHub Copilot CLI
       - name: Install GitHub Copilot CLI
-        run: npm install -g @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.27' }}
+        run: npm install -g @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.68' }}
 
       - name: 狀態更新處理
         if: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.event_data == 'StatusUpdate') || inputs.event_data == 'StatusUpdate' }}
@@ -111,7 +110,7 @@ jobs:
         id: copilot_task
         shell: bash
         env:
-          COPILOT_GITHUB_TOKEN: ${{ env.COPILOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           COPILOT_HOME: ".copilot"
           FELO_API_KEY: ${{ env.FELO_API_KEY }}
         run: |
@@ -157,7 +156,7 @@ jobs:
           USER_PROMPT_CONTENT="$(cat "$USER_PROMPT_FILE")"
 
           set +e
-          npx -y @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.27' }} \
+          npx -y @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.68' }} \
             -p "請將最終結果寫入 artifacts/${COMMENT_ID}/result.md 。我的提示詞為: ${USER_PROMPT_CONTENT}" \
             --yolo --stream off --continue --output-format json \
             > "artifacts/${COMMENT_ID}/output.jsonl" \

--- a/templates/copilot-gemini-api/.github/workflows/issue-N.yml
+++ b/templates/copilot-gemini-api/.github/workflows/issue-N.yml
@@ -54,6 +54,7 @@ concurrency:
 permissions:
   contents: write
   issues: write
+  copilot-requests: write
 
 # 把不同 trigger 的 payload 統一整理成共用環境變數，後續 step 只要讀 env 即可。
 env:
@@ -61,8 +62,6 @@ env:
   ISSUE_NUMBER: "${{ github.event_name == 'repository_dispatch' && github.event.client_payload.issue_number || inputs.issue_number }}"
   # 若有提供現成的 comment id，就直接更新那則留言。
   COMMENT_ID: "${{ github.event_name == 'repository_dispatch' && github.event.client_payload.comment_id || inputs.comment_id }}"
-  # 給 Copilot CLI 做 GitHub 驗證用的 token；實際權限要看 repo secrets 如何配置。
-  COPILOT_GITHUB_TOKEN: "${{ secrets.COPILOT_GITHUB_TOKEN }}"
   USER_COMMENT_ID: "${{ github.event_name == 'repository_dispatch' && github.event.client_payload.user_comment_id || inputs.user_comment_id }}"
   # 給 Copilot CLI 做 Gemini API 認證用的金鑰；實際權限要看 repo secrets 如何配置。
   GEMINI_API_KEY: "${{ secrets.GEMINI_API_KEY }}"
@@ -91,7 +90,7 @@ jobs:
 
       # 安裝 GitHub Copilot CLI
       - name: Install GitHub Copilot CLI
-        run: npm install -g @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.27' }}
+        run: npm install -g @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.68' }}
 
       - name: 狀態更新處理
         if: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.event_data == 'StatusUpdate') || inputs.event_data == 'StatusUpdate' }}
@@ -111,7 +110,7 @@ jobs:
         id: copilot_task
         shell: bash
         env:
-          COPILOT_GITHUB_TOKEN: ${{ env.COPILOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           COPILOT_HOME: ".copilot"
           GEMINI_API_KEY: ${{ env.GEMINI_API_KEY }}
         run: |
@@ -157,7 +156,7 @@ jobs:
           USER_PROMPT_CONTENT="$(cat "$USER_PROMPT_FILE")"
 
           set +e
-          npx -y @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.27' }} \
+          npx -y @github/copilot@${{ vars.COPILOT_CLI_VERSION || '1.0.68' }} \
             -p "請將最終結果寫入 artifacts/${COMMENT_ID}/result.md 。我的提示詞為: ${USER_PROMPT_CONTENT}" \
             --yolo --stream off --continue --output-format json \
             > "artifacts/${COMMENT_ID}/output.jsonl" \


### PR DESCRIPTION
## 概述
本 PR 將 GitHubClawToolkit 的 copilot 系列範本同步到新版 GitHub Copilot CLI in Actions 驗證模式，改為使用內建 `GITHUB_TOKEN`，並補齊所需權限設定。

## 問題描述
既有範本仍依賴 `COPILOT_GITHUB_TOKEN` secret 與舊版 CLI 預設值，導致設定流程較繁瑣，且與新版官方建議做法不一致。

## 解決方案
- 在 copilot 系列 workflow 加入 `copilot-requests: write` 權限。
- 移除 `COPILOT_GITHUB_TOKEN` 環境變數依賴，改由 `GITHUB_TOKEN: ${{ github.token }}` 提供驗證。
- 將 Copilot CLI 預設版本更新為 `1.0.68`。

## 變更內容
- [x] `templates/copilot-default/.github/workflows/issue-N.yml`
- [x] `templates/copilot-byok/.github/workflows/issue-N.yml`
- [x] `templates/copilot-felo/.github/workflows/issue-N.yml`
- [x] `templates/copilot-gemini-api/.github/workflows/issue-N.yml`

## 測試方式
由於本次為 workflow 設定與版本更新，主要以變更審查方式驗證：
- 比對 4 個範本均已改為 `GITHUB_TOKEN` 注入。
- 確認 4 個範本均已補 `copilot-requests: write`。
- 確認 4 個範本 CLI 預設版本一致升級至 `1.0.68`。

## 相關連結
- Issue: 無
- 參考：GitHub Changelog（Copilot CLI no longer needs a PAT in GitHub Actions）
